### PR TITLE
Refactor GHA

### DIFF
--- a/.github/workflows/test-max-opened-issues.yml
+++ b/.github/workflows/test-max-opened-issues.yml
@@ -1,0 +1,98 @@
+name: "Test - Max opened issues"
+
+on:
+  pull_request: {}
+  workflow_dispatch: {}
+
+env:
+  AWS_REGION: us-east-2
+
+# Permissions required for assuming AWS identity
+permissions:
+  id-token: write
+  contents: read
+  issues: write
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup
+        run: echo "Do setup"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: metadata
+          path: ./tests/fixtures/metadata
+          retention-days: 1
+
+  test:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: [setup]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Plan Atmos Component
+        id: current
+        uses: ./
+        with:
+          max-opened-issues: '4'
+          labels: "test-changes-exists"
+          token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+
+    outputs:
+      result: ${{ steps.current.outcome }}
+
+  assert:
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - uses: nick-fields/assert-action@v1
+        with:
+          expected: 'success'
+          actual: "${{ needs.test.outputs.result }}"
+
+      - name: Find all issues
+        id: issues
+        uses: lee-dohm/select-matching-issues@v1
+        with:
+          query: 'label:test-changes-exists is:open'
+          token: ${{ github.token }}
+
+      - name: Close found issues
+        id: test
+        run: |
+          echo "count=$(cat ${{ steps.issues.outputs.path }} | xargs -I {} -d '\n' echo "{}" | wc -l )" >> $GITHUB_OUTPUT
+
+      - uses: nick-fields/assert-action@v1
+        with:
+          expected: '4'
+          actual: "${{ steps.test.outputs.count }}"
+
+  teardown:
+    runs-on: ubuntu-latest
+    needs: [assert]
+    if: ${{ always() }}
+    steps:
+      - name: Tear down
+        run: echo "Do Tear down"
+
+      - name: Find all issues
+        id: issues
+        uses: lee-dohm/select-matching-issues@v1
+        with:
+          query: 'label:test-changes-exists is:open'
+          token: ${{ github.token }}
+
+      - name: Close found issues
+        run: cat ${{ steps.issues.outputs.path }} | xargs -I {} -d '\n' gh issue close {}
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/test-max-opened-issues.yml
+++ b/.github/workflows/test-max-opened-issues.yml
@@ -1,7 +1,7 @@
 name: "Test - Max opened issues"
 
 on:
-  pull_request: {}
+#  pull_request: {}
   workflow_dispatch: {}
 
 env:

--- a/.github/workflows/test-max-opened-issues.yml
+++ b/.github/workflows/test-max-opened-issues.yml
@@ -45,7 +45,7 @@ jobs:
         uses: ./
         with:
           max-opened-issues: '4'
-          labels: "test-changes-exists"
+          labels: "test-max-opened-issues"
           token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
 
     outputs:
@@ -64,7 +64,7 @@ jobs:
         id: issues
         uses: lee-dohm/select-matching-issues@v1
         with:
-          query: 'label:test-changes-exists is:open'
+          query: 'label:test-max-opened-issues is:open'
           token: ${{ github.token }}
 
       - name: Close found issues
@@ -89,7 +89,7 @@ jobs:
         id: issues
         uses: lee-dohm/select-matching-issues@v1
         with:
-          query: 'label:test-changes-exists is:open'
+          query: 'label:test-max-opened-issues is:open'
           token: ${{ github.token }}
 
       - name: Close found issues

--- a/.github/workflows/test-max-opened-issues.yml
+++ b/.github/workflows/test-max-opened-issues.yml
@@ -44,7 +44,7 @@ jobs:
         id: current
         uses: ./
         with:
-          max-opened-issues: '4'
+          max-opened-issues: '3'
           labels: "test-max-opened-issues"
           token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
 
@@ -75,7 +75,7 @@ jobs:
 
       - uses: nick-fields/assert-action@v1
         with:
-          expected: '4'
+          expected: '3'
           actual: "${{ steps.test.outputs.count }}"
 
   teardown:

--- a/.github/workflows/test-max-opened-issues.yml
+++ b/.github/workflows/test-max-opened-issues.yml
@@ -70,6 +70,7 @@ jobs:
       - name: Close found issues
         id: test
         run: |
+          cat ${{ steps.issues.outputs.path }}
           echo "count=$(cat ${{ steps.issues.outputs.path }} | xargs -I {} -d '\n' echo "{}" | wc -l )" >> $GITHUB_OUTPUT
 
       - uses: nick-fields/assert-action@v1

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: "Comma-separated list of additional labels to assign issues to."
     required: false
     default: ""
+  process-all:
+    description: "Process all issues or only the ones that relates to affected stacks. Default: false"
+    required: false
+    default: "false"
   token:
     description:
       Used to pull node distributions for Atmos from Cloud Posse's GitHub repository. Since there's a default, this is typically

--- a/src/action.js
+++ b/src/action.js
@@ -186,7 +186,7 @@ const driftDetectionTable = (results) => {
 const postStepSummaries = async (table, components) => {
   // GitHub limits summary per step to 1MB
   // https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#step-isolation-and-limits
-  const maximumLength = Math.pow(2, 20);
+  const maximumLength = Math.pow(2, 5);
   let totalLength = 0;
   let currentLength = 0;
 

--- a/src/action.js
+++ b/src/action.js
@@ -37,13 +37,14 @@ const downloadArtifacts = (artifactName) => {
 };
 
 
-const mapOpenGitHubIssuesToComponents = async (octokit, context) => {
+const mapOpenGitHubIssuesToComponents = async (octokit, context, labels) => {
     const repository = context.repo;
 
     const listIssues = async (per_page, page, result) => {
         const response = await octokit.rest.issues.listForRepo({
             ...repository,
             state: 'open',
+            labels: labels,
             per_page,
             page
         });
@@ -483,7 +484,7 @@ const runAction = async (octokit, context, parameters) => {
 
     const path = await downloadArtifacts("metadata");
 
-    const openGitHubIssuesToComponents = await mapOpenGitHubIssuesToComponents(octokit, context);
+    const openGitHubIssuesToComponents = await mapOpenGitHubIssuesToComponents(octokit, context, labels);
     // const componentsToIssueNumber = openGitHubIssuesToComponents.componentsToIssues;
     // const componentsToIssueMetadata = openGitHubIssuesToComponents.componentsToMetadata;
 

--- a/src/action.js
+++ b/src/action.js
@@ -447,19 +447,13 @@ const postDriftDetectionSummary = async (context, results) => {
 }
 
 const postStepSummaries = async (components) => {
-    components.map(
-        (component) => {
-            component.summary()
-        }
-    ).filter(
-        (summary) => {
-            return summary !== ""
-        }
-    ).map(
-        (summary) => {
-            return core.summary.addRaw(summary).write();
-        }
-    )
+    components.map((component) => {
+          return component.summary()
+    }).filter((summary) => {
+        return summary !== ""
+    }).map((summary) => {
+        return core.summary.addRaw(summary).write();
+    })
     // for (let i = 0; i < components.length; i++) {
     //   const slug = components[i];
     //   const file_name = slug.replace("/", "_")

--- a/src/action.js
+++ b/src/action.js
@@ -80,10 +80,9 @@ const readMetadataFromPlanArtifacts = (path) => {
     return new Map(result)
 }
 
-const triage = async (componentsToIssue, componentsToPlanState, users, labels, maxOpenedIssues) => {
+const triage = async (componentsToIssue, componentsToPlanState, users, labels, maxOpenedIssues, processAll) => {
 
-    const mode = "full"
-    const fullComponents = mode === "full" ?
+    const fullComponents = processAll ?
         [...componentsToIssue.keys(), ...componentsToPlanState.keys()] :
         [...componentsToPlanState.keys()]
     const slugs = [...new Set(fullComponents)]  // get unique set
@@ -210,7 +209,8 @@ const runAction = async (octokit, context, parameters) => {
         maxOpenedIssues = 0,
         assigneeUsers = [],
         assigneeTeams = [],
-        labels        = []
+        labels        = [],
+        processAll  = false,
     } = parameters;
 
     const metadataFromPlanArtifacts= await downloadArtifacts("metadata").then(
@@ -225,7 +225,7 @@ const runAction = async (octokit, context, parameters) => {
     let users = assigneeUsers.concat(usersFromTeams);
     users = [...new Set(users)]; // get unique set
 
-    const triageResults = await triage(openGitHubIssuesToComponents, metadataFromPlanArtifacts, users, labels, maxOpenedIssues);
+    const triageResults = await triage(openGitHubIssuesToComponents, metadataFromPlanArtifacts, users, labels, maxOpenedIssues, processAll);
 
     const results = await Promise.all(triageResults.map((operation) => {
         return operation.run(octokit, context)

--- a/src/action.js
+++ b/src/action.js
@@ -109,7 +109,7 @@ const triage = async (componentsToIssue, componentsToPlanState, users, labels, m
     })
 
     const openedIssuesCounts = operations.filter((operation) => {
-        return operation instanceof Create || operation instanceof Update
+        return operation instanceof Update
     }).length
 
     const closedIssuesCount = operations.filter((operation) => {

--- a/src/action.js
+++ b/src/action.js
@@ -82,7 +82,7 @@ const readMetadataFromPlanArtifacts = (path) => {
 
 const triage = async (componentsToIssue, componentsToPlanState, users, labels, maxOpenedIssues) => {
 
-    const mode = "full"
+    const mode = "partial" // full or partial
     const fullComponents = mode === "full" ?
         [...componentsToIssue.keys(), ...componentsToPlanState.keys()] :
         [...componentsToPlanState.keys()]

--- a/src/action.js
+++ b/src/action.js
@@ -112,30 +112,20 @@ const triage = async (componentsToIssue, componentsToPlanState, users, labels, m
         return operation instanceof Update
     }).length
 
-    const closedIssuesCount = operations.filter((operation) => {
-        return operation instanceof Close || operation instanceof Remove
-    }).length
-
     const numberOfMaximumPotentialIssuesThatCanBeCreated = Math.max(0, maxOpenedIssues - openedIssuesCounts);
+    // If maxOpenedIssues is negative then it will not limit the number of issues to create
     let numOfIssuesToCreate = Math.min(numberOfMaximumPotentialIssuesThatCanBeCreated, maxOpenedIssues);
 
-    console.log(openedIssuesCounts)
-    console.log(closedIssuesCount)
-    console.log(numberOfMaximumPotentialIssuesThatCanBeCreated)
-    console.log(numOfIssuesToCreate)
-
     return operations.map((operation) => {
-        const newOperation = operation instanceof Create && numOfIssuesToCreate === 0 ?
-            new Skip(operation.issue, operation.state, maxOpenedIssues) :
-            operation;
-
         if (operation instanceof Create) {
             if (numOfIssuesToCreate > 0) {
                 numOfIssuesToCreate -= 1
+            } else if (numOfIssuesToCreate === 0) {
+                return new Skip(operation.issue, operation.state, maxOpenedIssues);
             }
         }
 
-        return newOperation
+        return operation
     })
 }
 

--- a/src/action.js
+++ b/src/action.js
@@ -174,21 +174,21 @@ const triage = async (componentsToIssue, componentsToPlanState, users, labels, m
     console.log(closedIssuesCount);
     console.log(numOfIssuesToCreate);
 
-    // const result = operations.map((operation) => {
-    //     if ( operation instanceof Create  || operation instanceof Update ) {
-    //         if (numOfIssuesToCreate > 0) {
-    //             numOfIssuesToCreate -= 1
-    //         }
-    //     }
-    //
-    //     if ( operation instanceof Create && numOfIssuesToCreate === 0 ) {
-    //         return new Skip(operation.issue, operation.state, maxOpenedIssues)
-    //     }
-    //
-    //     return operation
-    // })
+    const result = operations.map((operation) => {
+        if ( operation instanceof Create  || operation instanceof Update ) {
+            if (numOfIssuesToCreate > 0) {
+                numOfIssuesToCreate -= 1
+            }
+        }
 
-    return operations
+        if ( operation instanceof Create && numOfIssuesToCreate === 0 ) {
+            return new Skip(operation.issue, operation.state, maxOpenedIssues)
+        }
+
+        return operation
+    })
+
+    return result
 
     // const componentsCandidatesToCreateIssue = [];
     // const componentsCandidatesToCloseIssue = [];

--- a/src/action.js
+++ b/src/action.js
@@ -186,7 +186,7 @@ const driftDetectionTable = (results) => {
 const postStepSummaries = async (table, components) => {
   // GitHub limits summary per step to 1MB
   // https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#step-isolation-and-limits
-  const maximumLength = Math.pow(2, 12);
+  const maximumLength = Math.pow(2, 13);
   let totalLength = 0;
   let currentLength = 0;
 

--- a/src/action.js
+++ b/src/action.js
@@ -10,7 +10,7 @@ const {Create} = require("./operations/create");
 const {Nothing} = require("./operations/nothing");
 const {StackFromArchive} = require("./models/stacks_from_archive");
 
-function getFileName(slug) {
+const getFileName = (slug) => {
   return slug.replace(/\//g, "_");
 }
 

--- a/src/action.js
+++ b/src/action.js
@@ -175,17 +175,17 @@ const triage = async (componentsToIssue, componentsToPlanState, users, labels, m
     console.log(numOfIssuesToCreate);
 
     const result = operations.map((operation) => {
-        if ( operation instanceof Create  || operation instanceof Update ) {
+        let result = operation instanceof Create && numOfIssuesToCreate === 0 ?
+            new Skip(operation.issue, operation.state, maxOpenedIssues) :
+            operation;
+
+        if ( operation instanceof Create || operation instanceof Update ) {
             if (numOfIssuesToCreate > 0) {
                 numOfIssuesToCreate -= 1
             }
         }
 
-        if ( operation instanceof Create && numOfIssuesToCreate === 0 ) {
-            return new Skip(operation.issue, operation.state, maxOpenedIssues)
-        }
-
-        return operation
+        return result
     })
 
     return result

--- a/src/action.js
+++ b/src/action.js
@@ -121,13 +121,16 @@ const readMetadataFromPlanArtifacts = (path) => {
 }
 
 
-const triage = async (componentsToIssue, componentsToPlanState, users, labels) => {
+const triage = async (componentsToIssue, componentsToPlanState, users, labels, maxOpenedIssues) => {
 
     const mode = "full"
     const fullComponents = mode === "full" ?
         [...componentsToIssue.keys(), ...componentsToPlanState.keys()] :
         [...componentsToPlanState.keys()]
     const slugs = new Set(fullComponents)
+
+    // const numberOfMaximumPotentialIssuesThatCanBeCreated = Math.max(0, maxOpenedIssues - Object.keys(componentsToIssues).length + componentsCandidatesToCloseIssue.length);
+    // const numOfIssuesToCreate = Math.min(numberOfMaximumPotentialIssuesThatCanBeCreated, componentsCandidatesToCreateIssue.length);
 
     const operations = [...slugs].map( (slug) => {
         const issue = componentsToIssue.get(slug)
@@ -472,7 +475,7 @@ const postStepSummaries = async (components) => {
  */
 const runAction = async (octokit, context, parameters) => {
     const {
-        // maxOpenedIssues = 0,
+        maxOpenedIssues = 0,
         assigneeUsers = [],
         assigneeTeams = [],
         labels        = []
@@ -491,7 +494,7 @@ const runAction = async (octokit, context, parameters) => {
     let users = assigneeUsers.concat(usersFromTeams);
     users = [...new Set(users)]; // get unique set
 
-    const triageResults = await triage(openGitHubIssuesToComponents, metadataFromPlanArtifacts, users, labels);
+    const triageResults = await triage(openGitHubIssuesToComponents, metadataFromPlanArtifacts, users, labels, maxOpenedIssues);
 
     const results = await Promise.all(triageResults.map((operation) => {
         return operation.run(octokit, context)

--- a/src/action.js
+++ b/src/action.js
@@ -167,7 +167,7 @@ const triage = async (componentsToIssue, componentsToPlanState, users, labels, m
     }).length
 
     const numberOfMaximumPotentialIssuesThatCanBeCreated = Math.max(0, maxOpenedIssues - openedIssuesCounts + closedIssuesCount);
-    let numOfIssuesToCreate = Math.min(numberOfMaximumPotentialIssuesThatCanBeCreated, openedIssuesCounts);
+    let numOfIssuesToCreate = Math.min(numberOfMaximumPotentialIssuesThatCanBeCreated, maxOpenedIssues);
 
     console.log(maxOpenedIssues);
     console.log(openedIssuesCounts);

--- a/src/action.js
+++ b/src/action.js
@@ -119,6 +119,11 @@ const triage = async (componentsToIssue, componentsToPlanState, users, labels, m
     const numberOfMaximumPotentialIssuesThatCanBeCreated = Math.max(0, maxOpenedIssues - openedIssuesCounts + closedIssuesCount);
     let numOfIssuesToCreate = Math.min(numberOfMaximumPotentialIssuesThatCanBeCreated, maxOpenedIssues);
 
+    console.log(openedIssuesCounts)
+    console.log(closedIssuesCount)
+    console.log(numberOfMaximumPotentialIssuesThatCanBeCreated)
+    console.log(numOfIssuesToCreate)
+
     return operations.map((operation) => {
         const newOperation = operation instanceof Create && numOfIssuesToCreate === 0 ?
             new Skip(operation.issue, operation.state, maxOpenedIssues) :

--- a/src/action.js
+++ b/src/action.js
@@ -121,7 +121,7 @@ const readMetadataFromPlanArtifacts = (path) => {
 }
 
 
-const triage = async (componentsToIssue, componentsToPlanState, users, labels, maxOpenedIssues) => {
+const triage = async (componentsToIssue, componentsToPlanState, users, labels) => {
 
     const mode = "full"
     const fullComponents = mode === "full" ?

--- a/src/action.js
+++ b/src/action.js
@@ -9,21 +9,6 @@ const {Remove} = require("./operations/remove");
 const {Create} = require("./operations/create");
 const {Nothing} = require("./operations/nothing");
 
-
-// const downloadArtifacts = async (artifactName) => {
-//     try {
-//         const artifactClient = artifact.create()
-//         const downloadDirectory = '.'
-//
-//         // Downloading the artifact
-//         const downloadResponse = await artifactClient.downloadArtifact(artifactName, downloadDirectory);
-//
-//         core.info(`Artifact ${artifactName} downloaded to ${downloadResponse.downloadPath}`);
-//       } catch (error) {
-//         throw new Error(`Failed to download artifacts: ${error.message}`);
-//       }
-// };
-
 const downloadArtifacts = (artifactName) => {
     const artifactClient = artifact.create()
     const downloadDirectory = '.'
@@ -35,7 +20,6 @@ const downloadArtifacts = (artifactName) => {
             return item.downloadPath
         })
 };
-
 
 const mapOpenGitHubIssuesToComponents = async (octokit, context, labels) => {
     const repository = context.repo;
@@ -73,31 +57,6 @@ const mapOpenGitHubIssuesToComponents = async (octokit, context, labels) => {
     ))
 }
 
-// const readMetadataFromPlanArtifacts = async () => {
-//     const files = fs.readdirSync('.');
-//     const metadataFiles = files.filter(file => file.endsWith('metadata.json'));
-//
-//     let componentsToState = {};
-//     let componentsToMetadata = {};
-//
-//     for (let i = 0; i < metadataFiles.length; i++) {
-//         const metadata = JSON.parse(fs.readFileSync(metadataFiles[i], 'utf8'));
-//
-//         const slug = `${metadata.stack}-${metadata.component}`;
-//
-//         componentsToState[slug] = {
-//             drifted: metadata.drifted,
-//             error: metadata.error
-//         };
-//         componentsToMetadata[slug] = metadata;
-//     }
-//
-//     return {
-//         componentsToState: componentsToState,
-//         componentsToMetadata: componentsToMetadata,
-//     };
-// }
-
 class StackFromArchive {
     constructor(metadata) {
         this.metadata = metadata;
@@ -121,194 +80,60 @@ const readMetadataFromPlanArtifacts = (path) => {
     return new Map(result)
 }
 
-
 const triage = async (componentsToIssue, componentsToPlanState, users, labels, maxOpenedIssues) => {
 
     const mode = "full"
     const fullComponents = mode === "full" ?
         [...componentsToIssue.keys(), ...componentsToPlanState.keys()] :
         [...componentsToPlanState.keys()]
-    const slugs = new Set(fullComponents)
+    const slugs = [...new Set(fullComponents)]  // get unique set
 
-    // const numberOfMaximumPotentialIssuesThatCanBeCreated = Math.max(0, maxOpenedIssues - Object.keys(componentsToIssues).length + componentsCandidatesToCloseIssue.length);
-    // const numOfIssuesToCreate = Math.min(numberOfMaximumPotentialIssuesThatCanBeCreated, componentsCandidatesToCreateIssue.length);
-
-    const operations = [...slugs].map( (slug) => {
+    const operations = slugs.map((slug) => {
         const issue = componentsToIssue.get(slug)
         const state = componentsToPlanState.get(slug)
         if (issue && state) {
             if (state.error || state.drifted) {
                 const commitSHA = issue.metadata.commitSHA;
                 const currentSHA = "${{ github.sha }}";
-                if (currentSHA === commitSHA) {
-                    return new Skip(issue, state)
-                } else {
-                    return new Update(issue, state, labels)
-                }
-            } else {
-                return new Close(issue, state)
+
+                return currentSHA === commitSHA ? new Skip(issue, state) : new Update(issue, state, labels)
             }
+            return new Close(issue, state)
+
         } else if (issue) {
-            // Added resolve to issue
             return new Remove(issue)
-        } else if (state && ( state.error || state.drifted)) {
+        } else if (state && (state.error || state.drifted)) {
             return new Create(state, users, labels)
-        } else {
-            return new Nothing()
         }
+
+        return new Nothing()
     })
 
-    const openedIssuesCounts = operations.filter( (operation) => {
+    const openedIssuesCounts = operations.filter((operation) => {
         return operation instanceof Update
     }).length
 
-    const closedIssuesCount = operations.filter( (operation) => {
+    const closedIssuesCount = operations.filter((operation) => {
         return operation instanceof Close || operation instanceof Remove
     }).length
 
     const numberOfMaximumPotentialIssuesThatCanBeCreated = Math.max(0, maxOpenedIssues - openedIssuesCounts + closedIssuesCount);
     let numOfIssuesToCreate = Math.min(numberOfMaximumPotentialIssuesThatCanBeCreated, maxOpenedIssues);
 
-    console.log(maxOpenedIssues);
-    console.log(openedIssuesCounts);
-    console.log(closedIssuesCount);
-    console.log(numOfIssuesToCreate);
-
-    const result = operations.map((operation) => {
-        let result = operation instanceof Create && numOfIssuesToCreate === 0 ?
+    return operations.map((operation) => {
+        const newOperation = operation instanceof Create && numOfIssuesToCreate === 0 ?
             new Skip(operation.issue, operation.state, maxOpenedIssues) :
             operation;
 
-        if ( operation instanceof Create || operation instanceof Update ) {
+        if (operation instanceof Create || operation instanceof Update) {
             if (numOfIssuesToCreate > 0) {
                 numOfIssuesToCreate -= 1
             }
         }
 
-        return result
+        return newOperation
     })
-
-    return result
-
-    // const componentsCandidatesToCreateIssue = [];
-    // const componentsCandidatesToCloseIssue = [];
-    // const componentsToUpdateExistingIssue = [];
-    // const removedComponents = [];
-    // const recoveredComponents = [];
-    // const driftingComponents = [];
-    // const erroredComponents = [];
-
-    // for (let slug of slugs) {
-    //     if (componentsToIssueNumber.hasOwnProperty(slug)) {
-    //         const issueNumber = componentsToIssueNumber[slug].number;
-    //
-    //         // if (componentsToPlanState.hasOwnProperty(slug)) {
-    //         //     // const drifted = componentsToPlanState[slug].drifted;
-    //         //     // const error = componentsToPlanState[slug].error;
-    //         //     //
-    //         //     // if (drifted || error) {
-    //         //     //     const commitSHA = componentsToIssueMetadata[slug].commitSHA;
-    //         //     //     const currentSHA = "${{ github.sha }}";
-    //         //     //     // if (currentSHA === commitSHA) {
-    //         //     //     //     core.info(`Component "${slug}" marked as drifted but default branch SHA didn't change so nothing to update. Skipping ...`);
-    //         //     //     //     if (error) {
-    //         //     //     //         erroredComponents.push(slug)
-    //         //     //     //     } else {
-    //         //     //     //         driftingComponents.push(slug);
-    //         //     //     //     }
-    //         //     //     // } else {
-    //         //     //     //     core.info(`Component "${slug}" is still drifting. Issue ${issueNumber} needs to be updated.`);
-    //         //     //     //     componentsToUpdateExistingIssue.push(slug);
-    //         //     //     //     if (error) {
-    //         //     //     //         erroredComponents.push(slug)
-    //         //     //     //     } else {
-    //         //     //     //         driftingComponents.push(slug);
-    //         //     //     //     }
-    //         //     //     // }
-    //         //     // } else {
-    //         //     //     core.info(`Component "${slug}" is not drifting anymore. Issue ${issueNumber} needs to be closed.`);
-    //         //     //     componentsCandidatesToCloseIssue.push(slug);
-    //         //     //     recoveredComponents.push(slug);
-    //         //     // }
-    //         // } else {
-    //         //     core.info(`Component "${slug}" has been removed. Issue ${issueNumber} needs to be closed.`);
-    //         //     componentsCandidatesToCloseIssue.push(slug);
-    //         //     removedComponents.push(slug);
-    //         // }
-    //     } else {
-    //         const drifted = componentsToPlanState[slug].drifted;
-    //         const error = componentsToPlanState[slug].error;
-    //
-    //         if (drifted) {
-    //             core.info(`Component "${slug}" drifted. New issue has to be created.`);
-    //             componentsCandidatesToCreateIssue.push(slug);
-    //             driftingComponents.push(slug);
-    //         } else if (error) {
-    //             core.info(`Component "${slug}" drift error. New issue has to be created.`);
-    //             componentsCandidatesToCreateIssue.push(slug);
-    //             erroredComponents.push(slug);
-    //         } else {
-    //             core.info(`Component "${slug}" is not drifting. Skipping ...`);
-    //         }
-    //     }
-    // }
-    // return operations
-    // return {
-    //     componentsCandidatesToCreateIssue: componentsCandidatesToCreateIssue,
-    //     componentsToUpdateExistingIssue: componentsToUpdateExistingIssue,
-    //     removedComponents: removedComponents,
-    //     recoveredComponents: recoveredComponents,
-    //     driftingComponents: driftingComponents,
-    //     erroredComponents: erroredComponents,
-    //     componentsCandidatesToCloseIssue: componentsCandidatesToCloseIssue,
-    // }
 }
-
-// const closeIssues = async (octokit, context, componentsToIssueNumber, removedComponents, recoveredComponents) => {
-//     const componentsToCloseIssuesFor = removedComponents.concat(recoveredComponents);
-//
-//     const repository = context.repo;
-//
-//     for (let i = 0; i < componentsToCloseIssuesFor.length; i++) {
-//       const slug = componentsToCloseIssuesFor[i];
-//       const issueNumber = componentsToIssueNumber[slug].number;
-//
-//       octokit.rest.issues.update({
-//         ...repository,
-//         issue_number: issueNumber,
-//         state: "closed"
-//       });
-//
-//       if (componentsToIssueNumber[slug].error) {
-//           octokit.rest.issues.addLabels({
-//               ...repository,
-//               issue_number: issueNumber,
-//               labels: ['error-recovered']
-//           });
-//       } else {
-//           octokit.rest.issues.addLabels({
-//               ...repository,
-//               issue_number: issueNumber,
-//               labels: ['drift-recovered']
-//           });
-//       }
-//
-//       let comment =  `Component \`${slug}\` is not drifting anymore`;
-//       if ( removedComponents.hasOwnProperty(slug) ) {
-//           comment = `Component \`${slug}\` has been removed`;
-//       } else if ( componentsToIssueNumber[slug].error ) {
-//           comment =  `Failure \`${slug}\` solved`;
-//       }
-//
-//       octokit.rest.issues.createComment({
-//         ...repository,
-//         issue_number: issueNumber,
-//         body: comment,
-//       });
-//
-//       core.info(`Issue ${issueNumber} for component ${slug} has been closed with comment: ${comment}`);
-//     }
-// }
 
 const convertTeamsToUsers = async (octokit, orgName, teams) => {
     let users = [];
@@ -340,69 +165,6 @@ const convertTeamsToUsers = async (octokit, orgName, teams) => {
     return users;
 }
 
-// const createIssues = async (octokit, context, maxOpenedIssues, labels, users, componentsToIssues, componentsCandidatesToCreateIssue, componentsCandidatesToCloseIssue, erroredComponents) => {
-//     const repository = context.repo;
-//     const numberOfMaximumPotentialIssuesThatCanBeCreated = Math.max(0, maxOpenedIssues - Object.keys(componentsToIssues).length + componentsCandidatesToCloseIssue.length);
-//     const numOfIssuesToCreate = Math.min(numberOfMaximumPotentialIssuesThatCanBeCreated, componentsCandidatesToCreateIssue.length);
-//     const componentsToNewlyCreatedIssues = {};
-//
-//     for (let i = 0; i < numOfIssuesToCreate; i++) {
-//         const slug = componentsCandidatesToCreateIssue[i];
-//         const issueTitle = erroredComponents.includes(slug) ? `Failure Detected in \`${slug}\`` : `Drift Detected in \`${slug}\``;
-//         const file_name = slug.replace("/", "_")
-//         const issueDescription = fs.readFileSync(`issue-description-${file_name}.md`, 'utf8');
-//
-//         const label  = erroredComponents.includes(slug) ? "error" : "drift"
-//
-//         const newIssue = await octokit.rest.issues.create({
-//             ...repository,
-//             title: issueTitle,
-//             body: issueDescription,
-//             labels: [label].concat(labels)
-//         });
-//
-//         const issueNumber = newIssue.data.number;
-//
-//         componentsToNewlyCreatedIssues[slug] = issueNumber;
-//
-//         core.info(`Created new issue with number: ${issueNumber}`);
-//
-//         core.setOutput('issue-number', issueNumber);
-//
-//         if (users.length > 0) {
-//             try {
-//                 await octokit.rest.issues.addAssignees({
-//                     ...repository,
-//                     issue_number: issueNumber,
-//                     assignees: users
-//                 });
-//             } catch (error) {
-//                 core.error(`Failed to associate user to an issue. Error ${error.message}`);
-//             }
-//         }
-//     }
-//
-//     return componentsToNewlyCreatedIssues;
-// }
-
-// const updateIssues = async (octokit, context, componentsToIssues, componentsToUpdateExistingIssue) => {
-//     const repository = context.repo;
-//
-//     for (let i = 0; i < componentsToUpdateExistingIssue.length; i++) {
-//       const slug = componentsToUpdateExistingIssue[i];
-//       const file_name = slug.replace("/", "_")
-//       const issueDescription = fs.readFileSync(`issue-description-${file_name}.md`, 'utf8');
-//       const issueNumber = componentsToIssues[slug].number;
-//
-//       octokit.rest.issues.update({
-//         ...repository,
-//         issue_number: issueNumber,
-//         body: issueDescription
-//       });
-//
-//       core.info(`Updated issue: ${issueNumber}`);
-//     }
-// }
 
 const postDriftDetectionSummary = async (context, results) => {
     const table = [ `| Component | State | Comments |`];
@@ -415,61 +177,6 @@ const postDriftDetectionSummary = async (context, results) => {
     }).forEach((result) => {
         table.push(result)
     })
-
-    // for (let slug of Object.keys(componentsToNewlyCreatedIssues)) {
-    //   const issueNumber = componentsToNewlyCreatedIssues[slug];
-    //
-    //   if (driftingComponents.includes(slug)) {
-    //       table.push( `| [${slug}](https://github.com/${orgName}/${repo}/actions/runs/${runId}#user-content-result-${slug}) | ![drifted](https://shields.io/badge/DRIFTED-important?style=for-the-badge "Drifted") | New drift detected. Created new issue [#${issueNumber}](https://github.com/${orgName}/${repo}/issues/${issueNumber}) |`);
-    //   } else if (erroredComponents.includes(slug)) {
-    //       table.push( `| [${slug}](https://github.com/${orgName}/${repo}/actions/runs/${runId}#user-content-result-${slug}) | ![failed](https://shields.io/badge/FAILED-ff0000?style=for-the-badge "Failed") | Failure detected. Created new issue [#${issueNumber}](https://github.com/${orgName}/${repo}/issues/${issueNumber}) |`);
-    //   }
-    // }
-
-    // for (let i = 0; i < componentsCandidatesToCreateIssue.length; i++) {
-    //   const slug = componentsCandidatesToCreateIssue[i];
-    //
-    //   if (!componentsToNewlyCreatedIssues.hasOwnProperty(slug)) {
-    //     if (driftingComponents.includes(slug)) {
-    //       table.push( `| [${slug}](https://github.com/${orgName}/${repo}/actions/runs/${runId}#user-content-result-${slug}) | ![drifted](https://shields.io/badge/DRIFTED-important?style=for-the-badge "Drifted") | New drift detected. Issue was not created because maximum number of created issues ${maxOpenedIssues} reached |`);
-    //     } else if (erroredComponents.includes(slug)) {
-    //       table.push( `| [${slug}](https://github.com/${orgName}/${repo}/actions/runs/${runId}#user-content-result-${slug}) | ![failed](https://shields.io/badge/FAILED-ff0000?style=for-the-badge "Failed") | Failure detected. Issue was not created because maximum number of created issues ${maxOpenedIssues} reached |`);
-    //     }
-    //   }
-    // }
-
-    // for (let i = 0; i < removedComponents.length; i++) {
-    //   const slug = removedComponents[i];
-    //   const issueNumber = componentsToIssues[slug].number;
-    //
-    //   table.push( `| [${slug}](https://github.com/${orgName}/${repo}/actions/runs/${runId}#user-content-result-${slug}) | ![removed](https://shields.io/badge/REMOVED-grey?style=for-the-badge "Removed") | Component has been removed. Closed issue [#${issueNumber}](https://github.com/${orgName}/${repo}/issues/${issueNumber}) |`);
-    // }
-
-    // for (let i = 0; i < recoveredComponents.length; i++) {
-    //   const slug = recoveredComponents[i];
-    //   const issueNumber = componentsToIssues[slug].number;
-    //   if (componentsToIssues[slug].error) {
-    //       table.push( `| [${slug}](https://github.com/${orgName}/${repo}/actions/runs/${runId}#user-content-result-${slug}) | ![recovered](https://shields.io/badge/RECOVERED-brightgreen?style=for-the-badge "Recovered") | Failure recovered. Closed issue [#${issueNumber}](https://github.com/${orgName}/${repo}/issues/${issueNumber}) |`);
-    //   } else {
-    //       table.push( `| [${slug}](https://github.com/${orgName}/${repo}/actions/runs/${runId}#user-content-result-${slug}) | ![recovered](https://shields.io/badge/RECOVERED-brightgreen?style=for-the-badge "Recovered") | Drift recovered. Closed issue [#${issueNumber}](https://github.com/${orgName}/${repo}/issues/${issueNumber}) |`);
-    //   }
-    // }
-
-    // for (let i = 0; i < driftingComponents.length; i++) {
-    //   const slug = driftingComponents[i];
-    //   if (componentsCandidatesToCreateIssue.indexOf(slug) === -1) {
-    //       const issueNumber = componentsToIssues[slug].number;
-    //       table.push( `| [${slug}](https://github.com/${orgName}/${repo}/actions/runs/${runId}#user-content-result-${slug}) | ![drifted](https://shields.io/badge/DRIFTED-important?style=for-the-badge "Drifted") | Drift detected. Issue already exists [#${issueNumber}](https://github.com/${orgName}/${repo}/issues/${issueNumber}) |`);
-    //   }
-    // }
-    //
-    // for (let i = 0; i < erroredComponents.length; i++) {
-    //     const slug = erroredComponents[i];
-    //     if (componentsCandidatesToCreateIssue.indexOf(slug) === -1) {
-    //         const issueNumber = componentsToIssues[slug].number;
-    //         table.push( `| [${slug}](https://github.com/${orgName}/${repo}/actions/runs/${runId}#user-content-result-${slug}) | ![failed](https://shields.io/badge/FAILED-ff0000?style=for-the-badge "Failed") | Failure detected. Issue already exists [#${issueNumber}](https://github.com/${orgName}/${repo}/issues/${issueNumber}) |`);
-    //     }
-    // }
 
     if (table.length > 1) {
       await core.summary
@@ -491,14 +198,6 @@ const postStepSummaries = async (components) => {
     for (const summary of summaries) {
         await core.summary.addRaw(summary, true).write();
     }
-    // for (let i = 0; i < components.length; i++) {
-    //   const slug = components[i];
-    //   const file_name = slug.replace("/", "_")
-    //   const file = `step-summary-${file_name}.md`;
-    //   const content = fs.readFileSync(file, 'utf-8');
-    //
-    //   await core.summary.addRaw(content).write();
-    // }
 }
 
 /**
@@ -517,11 +216,8 @@ const runAction = async (octokit, context, parameters) => {
     const path = await downloadArtifacts("metadata");
 
     const openGitHubIssuesToComponents = await mapOpenGitHubIssuesToComponents(octokit, context, labels);
-    // const componentsToIssueNumber = openGitHubIssuesToComponents.componentsToIssues;
-    // const componentsToIssueMetadata = openGitHubIssuesToComponents.componentsToMetadata;
 
     const metadataFromPlanArtifacts = readMetadataFromPlanArtifacts(path);
-    // const componentsToPlanState = metadataFromPlanArtifacts.componentsToState;
 
     const usersFromTeams = await convertTeamsToUsers(octokit, context.repo.owner, assigneeTeams);
     let users = assigneeUsers.concat(usersFromTeams);
@@ -533,26 +229,10 @@ const runAction = async (octokit, context, parameters) => {
         return operation.run(octokit, context)
     }))
 
-    // const componentsCandidatesToCreateIssue = triageResults.componentsCandidatesToCreateIssue;
-    // const componentsToUpdateExistingIssue = triageResults.componentsToUpdateExistingIssue;
-    // const removedComponents = triageResults.removedComponents;
-    // const recoveredComponents = triageResults.recoveredComponents;
-    // const driftingComponents = triageResults.driftingComponents;
-    // const erroredComponents = triageResults.erroredComponents;
-    // const componentsCandidatesToCloseIssue = triageResults.componentsCandidatesToCloseIssue;
-
-    // await closeIssues(octokit, context, componentsToIssueNumber, removedComponents, recoveredComponents);
-
-
-    // const componentsToNewlyCreatedIssues = await createIssues(octokit, context, maxOpenedIssues, labels, users, componentsToIssueNumber, componentsCandidatesToCreateIssue, componentsCandidatesToCloseIssue, erroredComponents);
-    //
-    // await updateIssues(octokit, context, componentsToIssueNumber, componentsToUpdateExistingIssue);
-
     await postDriftDetectionSummary(context, results);
-
-    postStepSummaries(triageResults);
-};
+    await postStepSummaries(triageResults);
+}
 
 module.exports = {
     runAction
-};
+}

--- a/src/action.js
+++ b/src/action.js
@@ -213,11 +213,13 @@ const runAction = async (octokit, context, parameters) => {
         labels        = []
     } = parameters;
 
-    const path = await downloadArtifacts("metadata");
+    const metadataFromPlanArtifacts= await downloadArtifacts("metadata").then(
+        (path) => {
+            return readMetadataFromPlanArtifacts(path)
+        }
+    )
 
     const openGitHubIssuesToComponents = await mapOpenGitHubIssuesToComponents(octokit, context, labels);
-
-    const metadataFromPlanArtifacts = readMetadataFromPlanArtifacts(path);
 
     const usersFromTeams = await convertTeamsToUsers(octokit, context.repo.owner, assigneeTeams);
     let users = assigneeUsers.concat(usersFromTeams);

--- a/src/action.js
+++ b/src/action.js
@@ -446,12 +446,13 @@ const postDriftDetectionSummary = async (context, results) => {
     }
 }
 
-const postStepSummaries = async (components) => {
-    components.map((component) => {
+const postStepSummaries = (components) => {
+    const test = components.map((component) => {
           return component.summary()
     }).filter((summary) => {
         return summary !== ""
     })
+    console.log(test);
     //     .forEach((summary) => {
     //     core.summary.addRaw(summary).write();
     // })
@@ -514,7 +515,7 @@ const runAction = async (octokit, context, parameters) => {
 
     await postDriftDetectionSummary(context, results);
 
-    await postStepSummaries(triageResults);
+    postStepSummaries(triageResults);
 };
 
 module.exports = {

--- a/src/action.js
+++ b/src/action.js
@@ -446,14 +446,14 @@ const postDriftDetectionSummary = async (context, results) => {
     }
 }
 
-const postStepSummaries = (components) => {
-    components.map((component) => {
+const postStepSummaries = async (components) => {
+    await Promise.all(components.map((component) => {
           return component.summary()
     }).filter((summary) => {
         return summary !== ""
-    }).forEach((summary) => {
-        core.summary.addRaw(summary).write();
-    })
+    }).map((summary) => {
+        return core.summary.addRaw(summary).write();
+    }))
     // for (let i = 0; i < components.length; i++) {
     //   const slug = components[i];
     //   const file_name = slug.replace("/", "_")

--- a/src/action.js
+++ b/src/action.js
@@ -8,6 +8,11 @@ const {Close} = require("./operations/close");
 const {Remove} = require("./operations/remove");
 const {Create} = require("./operations/create");
 const {Nothing} = require("./operations/nothing");
+const {StackFromArchive} = require("./models/stacks_from_archive");
+
+function getFileName(slug) {
+  return slug.replace(/\//g, "_");
+}
 
 const downloadArtifacts = (artifactName) => {
   const artifactClient = artifact.create()
@@ -57,15 +62,6 @@ const mapOpenGitHubIssuesToComponents = async (octokit, context, labels) => {
       return [stackFromIssue.slug, stackFromIssue]
     }
   ))
-}
-
-class StackFromArchive {
-  constructor(metadata) {
-    this.metadata = metadata;
-    this.drifted = metadata.drifted;
-    this.error = metadata.error;
-    this.slug = `${metadata.stack}-${metadata.component}`;
-  }
 }
 
 const readMetadataFromPlanArtifacts = (path) => {
@@ -259,5 +255,6 @@ const runAction = async (octokit, context, parameters) => {
 }
 
 module.exports = {
-  runAction
+  runAction,
+  getFileName
 }

--- a/src/action.js
+++ b/src/action.js
@@ -186,7 +186,7 @@ const driftDetectionTable = (results) => {
 const postStepSummaries = async (table, components) => {
   // GitHub limits summary per step to 1MB
   // https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#step-isolation-and-limits
-  const maximumLength = Math.pow(2, 10);
+  const maximumLength = Math.pow(2, 12);
   let totalLength = 0;
   let currentLength = 0;
 

--- a/src/action.js
+++ b/src/action.js
@@ -10,190 +10,216 @@ const {Create} = require("./operations/create");
 const {Nothing} = require("./operations/nothing");
 
 const downloadArtifacts = (artifactName) => {
-    const artifactClient = artifact.create()
-    const downloadDirectory = '.'
+  const artifactClient = artifact.create()
+  const downloadDirectory = '.'
 
-    // Downloading the artifact
-    return artifactClient.downloadArtifact(artifactName, downloadDirectory)
-        .then((item) => {
-            core.info(`Artifact ${artifactName} downloaded to ${item.downloadPath}`);
-            return item.downloadPath
-        })
+  // Downloading the artifact
+  return artifactClient.downloadArtifact(artifactName, downloadDirectory)
+    .then((item) => {
+      core.info(`Artifact ${artifactName} downloaded to ${item.downloadPath}`);
+      return item.downloadPath
+    })
 };
 
 const mapOpenGitHubIssuesToComponents = async (octokit, context, labels) => {
-    const repository = context.repo;
+  const repository = context.repo;
 
-    const listIssues = async (per_page, page, result) => {
-        const response = await octokit.rest.issues.listForRepo({
-            ...repository,
-            state: 'open',
-            labels: labels,
-            per_page,
-            page
-        });
+  const listIssues = async (per_page, page, result) => {
+    const response = await octokit.rest.issues.listForRepo({
+      ...repository,
+      state: 'open',
+      labels: labels,
+      per_page,
+      page
+    });
 
-        if (response.data.length === 0) {
-            return result
-        }
-
-        const driftDetectionIssues = response.data.filter(
-            issue => issue.title.startsWith('Drift Detected in') || issue.title.startsWith('Failure Detected in')
-        ).filter(
-            issue => getMetadataFromIssueBody(issue.body) !== null
-        );
-
-        const result_partition = driftDetectionIssues.map(issue => {
-            return new StackFromIssue(issue);
-        })
-
-        return await listIssues(per_page, page+1, result.concat(result_partition))
+    if (response.data.length === 0) {
+      return result
     }
 
-    let per_page = 100; // Max allowed value per page
-    let result = await listIssues(per_page, 1, [])
-    return new Map(result.map(
-        (stackFromIssue) => {
-            return [stackFromIssue.slug, stackFromIssue]
-        }
-    ))
+    const driftDetectionIssues = response.data.filter(
+      issue => issue.title.startsWith('Drift Detected in') || issue.title.startsWith('Failure Detected in')
+    ).filter(
+      issue => getMetadataFromIssueBody(issue.body) !== null
+    );
+
+    const result_partition = driftDetectionIssues.map(issue => {
+      return new StackFromIssue(issue);
+    })
+
+    return await listIssues(per_page, page + 1, result.concat(result_partition))
+  }
+
+  let per_page = 100; // Max allowed value per page
+  let result = await listIssues(per_page, 1, [])
+  return new Map(result.map(
+    (stackFromIssue) => {
+      return [stackFromIssue.slug, stackFromIssue]
+    }
+  ))
 }
 
 class StackFromArchive {
-    constructor(metadata) {
-        this.metadata = metadata;
-        this.drifted = metadata.drifted;
-        this.error = metadata.error;
-        this.slug = `${metadata.stack}-${metadata.component}`;
-    }
+  constructor(metadata) {
+    this.metadata = metadata;
+    this.drifted = metadata.drifted;
+    this.error = metadata.error;
+    this.slug = `${metadata.stack}-${metadata.component}`;
+  }
 }
 
 const readMetadataFromPlanArtifacts = (path) => {
-    const files = fs.readdirSync(path);
-    const metadataFiles = files.filter(file => file.endsWith('metadata.json'));
-    const result = metadataFiles.map(
-        (file) => {
-            const metadata = JSON.parse(fs.readFileSync(file, 'utf8'));
+  const files = fs.readdirSync(path);
+  const metadataFiles = files.filter(file => file.endsWith('metadata.json'));
+  const result = metadataFiles.map(
+    (file) => {
+      const metadata = JSON.parse(fs.readFileSync(file, 'utf8'));
 
-            const stackFromArchive = new StackFromArchive(metadata);
-            return [stackFromArchive.slug, stackFromArchive]
-        }
-    )
-    return new Map(result)
+      const stackFromArchive = new StackFromArchive(metadata);
+      return [stackFromArchive.slug, stackFromArchive]
+    }
+  )
+  return new Map(result)
 }
 
 const triage = async (componentsToIssue, componentsToPlanState, users, labels, maxOpenedIssues, processAll) => {
 
-    const fullComponents = processAll ?
-        [...componentsToIssue.keys(), ...componentsToPlanState.keys()] :
-        [...componentsToPlanState.keys()]
-    const slugs = [...new Set(fullComponents)]  // get unique set
+  const fullComponents = processAll ?
+    [...componentsToIssue.keys(), ...componentsToPlanState.keys()] :
+    [...componentsToPlanState.keys()]
+  const slugs = [...new Set(fullComponents)]  // get unique set
 
-    const operations = slugs.map((slug) => {
-        const issue = componentsToIssue.get(slug)
-        const state = componentsToPlanState.get(slug)
-        if (issue && state) {
-            if (state.error || state.drifted) {
-                const commitSHA = issue.metadata.commitSHA;
-                const currentSHA = "${{ github.sha }}";
+  const operations = slugs.map((slug) => {
+    const issue = componentsToIssue.get(slug)
+    const state = componentsToPlanState.get(slug)
+    if (issue && state) {
+      if (state.error || state.drifted) {
+        const commitSHA = issue.metadata.commitSHA;
+        const currentSHA = "${{ github.sha }}";
 
-                return currentSHA === commitSHA ? new Skip(issue, state) : new Update(issue, state, labels)
-            }
-            return new Close(issue, state)
+        return currentSHA === commitSHA ? new Skip(issue, state) : new Update(issue, state, labels)
+      }
+      return new Close(issue, state)
 
-        } else if (issue) {
-            return new Remove(issue)
-        } else if (state && (state.error || state.drifted)) {
-            return new Create(state, users, labels)
-        }
+    } else if (issue) {
+      return new Remove(issue)
+    } else if (state && (state.error || state.drifted)) {
+      return new Create(state, users, labels)
+    }
 
-        return new Nothing()
-    })
+    return new Nothing()
+  })
 
-    const openedIssuesCounts = operations.filter((operation) => {
-        return operation instanceof Update
-    }).length
+  const openedIssuesCounts = operations.filter((operation) => {
+    return operation instanceof Update
+  }).length
 
-    const numberOfMaximumPotentialIssuesThatCanBeCreated = Math.max(0, maxOpenedIssues - openedIssuesCounts);
-    // If maxOpenedIssues is negative then it will not limit the number of issues to create
-    let numOfIssuesToCreate = Math.min(numberOfMaximumPotentialIssuesThatCanBeCreated, maxOpenedIssues);
+  const numberOfMaximumPotentialIssuesThatCanBeCreated = Math.max(0, maxOpenedIssues - openedIssuesCounts);
+  // If maxOpenedIssues is negative then it will not limit the number of issues to create
+  let numOfIssuesToCreate = Math.min(numberOfMaximumPotentialIssuesThatCanBeCreated, maxOpenedIssues);
 
-    return operations.map((operation) => {
-        if (operation instanceof Create) {
-            if (numOfIssuesToCreate > 0) {
-                numOfIssuesToCreate -= 1
-            } else if (numOfIssuesToCreate === 0) {
-                return new Skip(operation.issue, operation.state, maxOpenedIssues);
-            }
-        }
+  return operations.map((operation) => {
+    if (operation instanceof Create) {
+      if (numOfIssuesToCreate > 0) {
+        numOfIssuesToCreate -= 1
+      } else if (numOfIssuesToCreate === 0) {
+        return new Skip(operation.issue, operation.state, maxOpenedIssues);
+      }
+    }
 
-        return operation
-    })
+    return operation
+  })
 }
 
 const convertTeamsToUsers = async (octokit, orgName, teams) => {
-    let users = [];
+  let users = [];
 
-    if (teams.length === 0) {
-        console.log("No users to assign issue with. Skipping ...");
-    } else {
-        try {
-            let usersFromTeams = [];
+  if (teams.length === 0) {
+    console.log("No users to assign issue with. Skipping ...");
+  } else {
+    try {
+      let usersFromTeams = [];
 
-            for (let i = 0; i < teams.length; i++) {
-                const response = await octokit.rest.teams.listMembersInOrg({
-                    org: orgName,
-                    team_slug: teams[i]
-                });
+      for (let i = 0; i < teams.length; i++) {
+        const response = await octokit.rest.teams.listMembersInOrg({
+          org: orgName,
+          team_slug: teams[i]
+        });
 
-                const usersForCurrentTeam = response.data.map(user => user.login);
-                usersFromTeams = usersFromTeams.concat(usersForCurrentTeam);
-            }
+        const usersForCurrentTeam = response.data.map(user => user.login);
+        usersFromTeams = usersFromTeams.concat(usersForCurrentTeam);
+      }
 
-            users = users.concat(usersFromTeams);
-            users = [...new Set(users)]; // get unique set
-        } catch (error) {
-            core.error(`Failed to associate user to an issue. Error ${error.message}`);
-            users = [];
-        }
+      users = users.concat(usersFromTeams);
+      users = [...new Set(users)]; // get unique set
+    } catch (error) {
+      core.error(`Failed to associate user to an issue. Error ${error.message}`);
+      users = [];
     }
+  }
 
-    return users;
+  return users;
 }
 
 
-const postDriftDetectionSummary = async (context, results) => {
-    const table = [ `| Component | State | Comments |`];
-    table.push(`|---|---|---|`)
+const driftDetectionTable = (results) => {
 
-    results.map( (result) => {
-        return result.render()
-    }).filter((result) => {
-        return result !== ""
-    }).forEach((result) => {
-        table.push(result)
-    })
+  const table = [`| Component | State | Comments |`];
+  table.push(`|---|---|---|`)
 
-    if (table.length > 2) {
-      await core.summary
-        .addRaw('# Drift Detection Summary', true)
-        .addRaw(table.join("\n"), true)
-        .addRaw("\n", true)
-        .write()
-    } else {
-      await core.summary.addRaw("No drift detected").write();
-    }
+  results.map((result) => {
+    return result.render()
+  }).filter((result) => {
+    return result !== ""
+  }).forEach((result) => {
+    table.push(result)
+  })
+
+  if (table.length > 2) {
+    return ['# Drift Detection Summary', table.join("\n")]
+  }
+
+  return ["No drift detected"]
+
 }
 
-const postStepSummaries = async (components) => {
-    const summaries = components.map((component) => {
-        return component.summary()
-    }).filter((summary) => {
-        return summary !== ""
-    })
-    for (const summary of summaries) {
-        await core.summary.addRaw(summary, true).write();
+const postStepSummaries = async (table, components) => {
+  // GitHub limits summary per step to 1MB
+  // https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#step-isolation-and-limits
+  const maximumLength = Math.poweredBy(2, 20);
+  let totalLength = 0;
+  let currentLength = 0;
+
+  totalLength += table.join("\n").length
+  let summary = core.summary.addRaw(table.join("\n"), true)
+
+  const componentsWithSummary = components.map((component) => {
+    const fullSummary = component.summary()
+    const shortSummary = component.shortSummary()
+
+    totalLength += fullSummary.length
+
+    return {
+      totalLength: totalLength,
+      fullSummary: fullSummary,
+      shortSummary: shortSummary
     }
+  }).filter((item) => {
+    return item.fullSummary !== ""
+  }).reverse().map((item) => {
+    if (item.totalLength + currentLength <= maximumLength) {
+      return item.fullSummary
+    }
+    currentLength += item.shortSummary.length
+    return item.shortSummary
+  }).reverse()
+
+
+  componentsWithSummary.forEach((item) => {
+    summary.addRaw(item, true)
+  })
+
+  await summary.write();
 }
 
 /**
@@ -202,36 +228,36 @@ const postStepSummaries = async (components) => {
  * @param {Object} parameters
  */
 const runAction = async (octokit, context, parameters) => {
-    const {
-        maxOpenedIssues = 0,
-        assigneeUsers = [],
-        assigneeTeams = [],
-        labels        = [],
-        processAll  = false,
-    } = parameters;
+  const {
+    maxOpenedIssues = 0,
+    assigneeUsers = [],
+    assigneeTeams = [],
+    labels = [],
+    processAll = false,
+  } = parameters;
 
-    const metadataFromPlanArtifacts= await downloadArtifacts("metadata").then(
-        (path) => {
-            return readMetadataFromPlanArtifacts(path)
-        }
-    )
+  const metadataFromPlanArtifacts = await downloadArtifacts("metadata").then(
+    (path) => {
+      return readMetadataFromPlanArtifacts(path)
+    }
+  )
 
-    const openGitHubIssuesToComponents = await mapOpenGitHubIssuesToComponents(octokit, context, labels);
+  const openGitHubIssuesToComponents = await mapOpenGitHubIssuesToComponents(octokit, context, labels);
 
-    const usersFromTeams = await convertTeamsToUsers(octokit, context.repo.owner, assigneeTeams);
-    let users = assigneeUsers.concat(usersFromTeams);
-    users = [...new Set(users)]; // get unique set
+  const usersFromTeams = await convertTeamsToUsers(octokit, context.repo.owner, assigneeTeams);
+  let users = assigneeUsers.concat(usersFromTeams);
+  users = [...new Set(users)]; // get unique set
 
-    const triageResults = await triage(openGitHubIssuesToComponents, metadataFromPlanArtifacts, users, labels, maxOpenedIssues, processAll);
+  const triageResults = await triage(openGitHubIssuesToComponents, metadataFromPlanArtifacts, users, labels, maxOpenedIssues, processAll);
 
-    const results = await Promise.all(triageResults.map((operation) => {
-        return operation.run(octokit, context)
-    }))
+  const results = await Promise.all(triageResults.map((operation) => {
+    return operation.run(octokit, context)
+  }))
 
-    await postDriftDetectionSummary(context, results);
-    await postStepSummaries(triageResults);
+  const table = driftDetectionTable(results);
+  await postStepSummaries(table, triageResults);
 }
 
 module.exports = {
-    runAction
+  runAction
 }

--- a/src/action.js
+++ b/src/action.js
@@ -439,6 +439,7 @@ const postDriftDetectionSummary = async (context, results) => {
       await core.summary
         .addRaw('# Drift Detection Summary', true)
         .addRaw(table.join("\n"), true)
+        .addRaw("\n", true)
         .write()
     } else {
       await core.summary.addRaw("No drift detected").write();

--- a/src/action.js
+++ b/src/action.js
@@ -490,8 +490,6 @@ const runAction = async (octokit, context, parameters) => {
     let users = assigneeUsers.concat(usersFromTeams);
     users = [...new Set(users)]; // get unique set
 
-
-
     const triageResults = await triage(openGitHubIssuesToComponents, metadataFromPlanArtifacts, users);
 
     const results = await Promise.all(triageResults.map((operation) => {
@@ -514,6 +512,8 @@ const runAction = async (octokit, context, parameters) => {
     // await updateIssues(octokit, context, componentsToIssueNumber, componentsToUpdateExistingIssue);
 
     await postDriftDetectionSummary(context, results);
+
+    console.log(triageResults);
 
     await postStepSummaries(triageResults);
 };

--- a/src/action.js
+++ b/src/action.js
@@ -451,9 +451,10 @@ const postStepSummaries = async (components) => {
           return component.summary()
     }).filter((summary) => {
         return summary !== ""
-    }).map((summary) => {
-        return core.summary.addRaw(summary).write();
     })
+    //     .forEach((summary) => {
+    //     core.summary.addRaw(summary).write();
+    // })
     // for (let i = 0; i < components.length; i++) {
     //   const slug = components[i];
     //   const file_name = slug.replace("/", "_")
@@ -512,8 +513,6 @@ const runAction = async (octokit, context, parameters) => {
     // await updateIssues(octokit, context, componentsToIssueNumber, componentsToUpdateExistingIssue);
 
     await postDriftDetectionSummary(context, results);
-
-    console.log(triageResults);
 
     await postStepSummaries(triageResults);
 };

--- a/src/action.js
+++ b/src/action.js
@@ -116,7 +116,7 @@ const triage = async (componentsToIssue, componentsToPlanState, users, labels, m
         return operation instanceof Close || operation instanceof Remove
     }).length
 
-    const numberOfMaximumPotentialIssuesThatCanBeCreated = Math.max(0, maxOpenedIssues - openedIssuesCounts + closedIssuesCount);
+    const numberOfMaximumPotentialIssuesThatCanBeCreated = Math.max(0, maxOpenedIssues - openedIssuesCounts);
     let numOfIssuesToCreate = Math.min(numberOfMaximumPotentialIssuesThatCanBeCreated, maxOpenedIssues);
 
     console.log(openedIssuesCounts)

--- a/src/action.js
+++ b/src/action.js
@@ -186,7 +186,7 @@ const driftDetectionTable = (results) => {
 const postStepSummaries = async (table, components) => {
   // GitHub limits summary per step to 1MB
   // https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#step-isolation-and-limits
-  const maximumLength = Math.pow(2, 14);
+  const maximumLength = Math.pow(2, 20);
   let totalLength = 0;
   let currentLength = 0;
 

--- a/src/action.js
+++ b/src/action.js
@@ -447,15 +447,13 @@ const postDriftDetectionSummary = async (context, results) => {
 }
 
 const postStepSummaries = (components) => {
-    const test = components.map((component) => {
+    components.map((component) => {
           return component.summary()
     }).filter((summary) => {
         return summary !== ""
+    }).forEach((summary) => {
+        core.summary.addRaw(summary).write();
     })
-    console.log(test);
-    //     .forEach((summary) => {
-    //     core.summary.addRaw(summary).write();
-    // })
     // for (let i = 0; i < components.length; i++) {
     //   const slug = components[i];
     //   const file_name = slug.replace("/", "_")

--- a/src/action.js
+++ b/src/action.js
@@ -374,6 +374,8 @@ const postDriftDetectionSummary = async (context, results) => {
 
     results.map( (result) => {
         return result.render()
+    }).filter((result) => {
+        return result !== ""
     }).forEach((result) => {
         table.push(result)
     })

--- a/src/action.js
+++ b/src/action.js
@@ -177,9 +177,7 @@ const postDriftDetectionSummary = async (context, results) => {
         table.push(result)
     })
 
-    console.log(table.length)
-
-    if (table.length > 1) {
+    if (table.length > 2) {
       await core.summary
         .addRaw('# Drift Detection Summary', true)
         .addRaw(table.join("\n"), true)

--- a/src/action.js
+++ b/src/action.js
@@ -186,7 +186,7 @@ const driftDetectionTable = (results) => {
 const postStepSummaries = async (table, components) => {
   // GitHub limits summary per step to 1MB
   // https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#step-isolation-and-limits
-  const maximumLength = Math.pow(2, 13);
+  const maximumLength = Math.pow(2, 14);
   let totalLength = 0;
   let currentLength = 0;
 

--- a/src/action.js
+++ b/src/action.js
@@ -177,6 +177,8 @@ const postDriftDetectionSummary = async (context, results) => {
         table.push(result)
     })
 
+    console.log(table.length)
+
     if (table.length > 1) {
       await core.summary
         .addRaw('# Drift Detection Summary', true)

--- a/src/action.js
+++ b/src/action.js
@@ -176,7 +176,6 @@ const driftDetectionTable = (results) => {
   }
 
   return ["No drift detected"]
-
 }
 
 const postStepSummaries = async (table, components) => {

--- a/src/action.js
+++ b/src/action.js
@@ -169,21 +169,23 @@ const triage = async (componentsToIssue, componentsToPlanState, users, labels, m
     const numberOfMaximumPotentialIssuesThatCanBeCreated = Math.max(0, maxOpenedIssues - openedIssuesCounts + closedIssuesCount);
     let numOfIssuesToCreate = Math.min(numberOfMaximumPotentialIssuesThatCanBeCreated, openedIssuesCounts);
 
-    const result = operations.map((operation) => {
-        if ( operation instanceof Create  || operation instanceof Update ) {
-            if (numOfIssuesToCreate > 0) {
-                numOfIssuesToCreate -= 1
-            }
-        }
+    console.log(numOfIssuesToCreate);
 
-        if ( operation instanceof Create && numOfIssuesToCreate === 0 ) {
-            return new Skip(operation.issue, operation.state, maxOpenedIssues)
-        }
+    // const result = operations.map((operation) => {
+    //     if ( operation instanceof Create  || operation instanceof Update ) {
+    //         if (numOfIssuesToCreate > 0) {
+    //             numOfIssuesToCreate -= 1
+    //         }
+    //     }
+    //
+    //     if ( operation instanceof Create && numOfIssuesToCreate === 0 ) {
+    //         return new Skip(operation.issue, operation.state, maxOpenedIssues)
+    //     }
+    //
+    //     return operation
+    // })
 
-        return operation
-    })
-
-    return result
+    return operations
 
     // const componentsCandidatesToCreateIssue = [];
     // const componentsCandidatesToCloseIssue = [];

--- a/src/action.js
+++ b/src/action.js
@@ -169,6 +169,9 @@ const triage = async (componentsToIssue, componentsToPlanState, users, labels, m
     const numberOfMaximumPotentialIssuesThatCanBeCreated = Math.max(0, maxOpenedIssues - openedIssuesCounts + closedIssuesCount);
     let numOfIssuesToCreate = Math.min(numberOfMaximumPotentialIssuesThatCanBeCreated, openedIssuesCounts);
 
+    console.log(maxOpenedIssues);
+    console.log(openedIssuesCounts);
+    console.log(closedIssuesCount);
     console.log(numOfIssuesToCreate);
 
     // const result = operations.map((operation) => {

--- a/src/action.js
+++ b/src/action.js
@@ -109,7 +109,7 @@ const triage = async (componentsToIssue, componentsToPlanState, users, labels, m
     })
 
     const openedIssuesCounts = operations.filter((operation) => {
-        return operation instanceof Update
+        return operation instanceof Create || operation instanceof Update
     }).length
 
     const closedIssuesCount = operations.filter((operation) => {

--- a/src/action.js
+++ b/src/action.js
@@ -82,7 +82,7 @@ const readMetadataFromPlanArtifacts = (path) => {
 
 const triage = async (componentsToIssue, componentsToPlanState, users, labels, maxOpenedIssues) => {
 
-    const mode = "partial" // full or partial
+    const mode = "full"
     const fullComponents = mode === "full" ?
         [...componentsToIssue.keys(), ...componentsToPlanState.keys()] :
         [...componentsToPlanState.keys()]

--- a/src/action.js
+++ b/src/action.js
@@ -447,13 +447,14 @@ const postDriftDetectionSummary = async (context, results) => {
 }
 
 const postStepSummaries = async (components) => {
-    await Promise.all(components.map((component) => {
-          return component.summary()
+    const summaries = components.map((component) => {
+        return component.summary()
     }).filter((summary) => {
         return summary !== ""
-    }).map((summary) => {
-        return core.summary.addRaw(summary).write();
-    }))
+    })
+    for (const summary of summaries) {
+        await core.summary.addRaw(summary, true).write();
+    }
     // for (let i = 0; i < components.length; i++) {
     //   const slug = components[i];
     //   const file_name = slug.replace("/", "_")

--- a/src/action.js
+++ b/src/action.js
@@ -129,7 +129,7 @@ const triage = async (componentsToIssue, componentsToPlanState, users, labels, m
             new Skip(operation.issue, operation.state, maxOpenedIssues) :
             operation;
 
-        if (operation instanceof Create || operation instanceof Update) {
+        if (operation instanceof Create) {
             if (numOfIssuesToCreate > 0) {
                 numOfIssuesToCreate -= 1
             }

--- a/src/action.js
+++ b/src/action.js
@@ -10,9 +10,6 @@ const {Create} = require("./operations/create");
 const {Nothing} = require("./operations/nothing");
 const {StackFromArchive} = require("./models/stacks_from_archive");
 
-const getFileName = (slug) => {
-  return slug.replace(/\//g, "_");
-}
 
 const downloadArtifacts = (artifactName) => {
   const artifactClient = artifact.create()
@@ -254,6 +251,5 @@ const runAction = async (octokit, context, parameters) => {
 }
 
 module.exports = {
-  runAction,
-  getFileName
+  runAction
 }

--- a/src/action.js
+++ b/src/action.js
@@ -186,7 +186,7 @@ const driftDetectionTable = (results) => {
 const postStepSummaries = async (table, components) => {
   // GitHub limits summary per step to 1MB
   // https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#step-isolation-and-limits
-  const maximumLength = Math.pow(2, 5);
+  const maximumLength = Math.pow(2, 10);
   let totalLength = 0;
   let currentLength = 0;
 

--- a/src/action.js
+++ b/src/action.js
@@ -186,7 +186,7 @@ const driftDetectionTable = (results) => {
 const postStepSummaries = async (table, components) => {
   // GitHub limits summary per step to 1MB
   // https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#step-isolation-and-limits
-  const maximumLength = Math.poweredBy(2, 20);
+  const maximumLength = Math.pow(2, 20);
   let totalLength = 0;
   let currentLength = 0;
 

--- a/src/action.js
+++ b/src/action.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const core = require('@actions/core');
 const artifact = require('@actions/artifact');
-const {StackFromIssue} = require("./models/stacks_from_issues");
+const {StackFromIssue, getMetadataFromIssueBody} = require("./models/stacks_from_issues");
 const {Skip} = require("./operations/skip");
 const {Update} = require("./operations/update");
 const {Close} = require("./operations/close");
@@ -39,6 +39,8 @@ const mapOpenGitHubIssuesToComponents = async (octokit, context, labels) => {
 
         const driftDetectionIssues = response.data.filter(
             issue => issue.title.startsWith('Drift Detected in') || issue.title.startsWith('Failure Detected in')
+        ).filter(
+            issue => getMetadataFromIssueBody(issue.body) !== null
         );
 
         const result_partition = driftDetectionIssues.map(issue => {

--- a/src/action.js
+++ b/src/action.js
@@ -159,7 +159,7 @@ const triage = async (componentsToIssue, componentsToPlanState, users, labels, m
     })
 
     const openedIssuesCounts = operations.filter( (operation) => {
-        return operation instanceof Create || operation instanceof Update
+        return operation instanceof Update
     }).length
 
     const closedIssuesCount = operations.filter( (operation) => {

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ try {
     const assigneeUsers = parseCsvInput(core.getInput('assignee-users'));
     const assigneeTeams = parseCsvInput(core.getInput('assignee-teams'));
     const labels        = parseCsvInput(core.getInput('labels'));
+    const processAll    = core.getBooleanInput('process-all');
 
     // Get octokit
     const octokit = github.getOctokit(token);
@@ -19,7 +20,8 @@ try {
         maxOpenedIssues,
         assigneeUsers,
         assigneeTeams,
-        labels
+        labels,
+        processAll
     });
 } catch (error) {
     core.setFailed(error.message);

--- a/src/models/stacks_from_archive.js
+++ b/src/models/stacks_from_archive.js
@@ -1,0 +1,12 @@
+class StackFromArchive {
+  constructor(metadata) {
+    this.metadata = metadata;
+    this.drifted = metadata.drifted;
+    this.error = metadata.error;
+    this.slug = `${metadata.stack}-${metadata.component}`;
+  }
+}
+
+module.exports = {
+  StackFromArchive,
+}

--- a/src/models/stacks_from_issues.js
+++ b/src/models/stacks_from_issues.js
@@ -4,9 +4,8 @@ const getMetadataFromIssueBody = (body) => {
 
     if (matched && matched[1]) {
         return JSON.parse(matched[1]);
-    } else {
-        throw new Error("Invalid metadata in the issue description");
     }
+    return null
 }
 
 class StackFromIssue {
@@ -21,5 +20,6 @@ class StackFromIssue {
 
 
 module.exports = {
-    StackFromIssue
+    StackFromIssue,
+    getMetadataFromIssueBody
 }

--- a/src/operations/close.js
+++ b/src/operations/close.js
@@ -36,7 +36,7 @@ class Close {
 
         core.info(`Issue ${issueNumber} for component ${slug} has been closed with comment: ${comment}`);
 
-        return new Recovered(context.runId, repository, this.issue, this.state)
+        return new Recovered(context.runId, repository, issueNumber, this.state)
     }
 
     summary() {

--- a/src/operations/close.js
+++ b/src/operations/close.js
@@ -43,6 +43,10 @@ class Close {
         return "";
     }
 
+    shortSummary() {
+        return "";
+    }
+
 }
 
 

--- a/src/operations/create.js
+++ b/src/operations/create.js
@@ -3,9 +3,10 @@ const {NewCreated} = require("../results/new-created");
 const {readFileSync} = require("fs");
 
 class Create {
-    constructor(state, users) {
+    constructor(state, users, labels) {
         this.state = state;
         this.users = users;
+        this.labels = labels;
     }
 
     async run(octokit, context) {
@@ -22,7 +23,7 @@ class Create {
             ...repository,
             title: issueTitle,
             body: issueDescription,
-            labels: [label]
+            labels: [label].concat(this.labels)
         });
 
         const issueNumber = newIssue.data.number;

--- a/src/operations/create.js
+++ b/src/operations/create.js
@@ -1,6 +1,7 @@
 const core = require("@actions/core");
 const {NewCreated} = require("../results/new-created");
 const {readFileSync} = require("fs");
+const {getFileName} = require("../action");
 
 class Create {
     constructor(state, users, labels) {
@@ -14,7 +15,7 @@ class Create {
 
         const slug = this.state.slug;
         const issueTitle = this.state.error ? `Failure Detected in \`${slug}\`` : `Drift Detected in \`${slug}\``;
-        const file_name = slug.replace("/", "_")
+        const file_name = getFileName(slug);
         const issueDescription = readFileSync(`issue-description-${file_name}.md`, 'utf8');
 
         const label = this.state.error ? "error" : "drift"
@@ -46,7 +47,7 @@ class Create {
     }
 
     summary() {
-        const file_name = this.state.slug.replace("/", "_")
+        const file_name = getFileName(this.state.slug);
         const file = `step-summary-${file_name}.md`;
         return readFileSync(file, 'utf-8');
     }

--- a/src/operations/create.js
+++ b/src/operations/create.js
@@ -41,7 +41,7 @@ class Create {
             }
         }
 
-        return new NewCreated(context.runId, repository, newIssue, this.state);
+        return new NewCreated(context.runId, repository, issueNumber, this.state);
     }
 
     summary() {

--- a/src/operations/create.js
+++ b/src/operations/create.js
@@ -57,7 +57,7 @@ class Create {
         const title = this.state.error ?
           `## Plan Failed for \`${component}\` in \`${stack}\`` :
           `## Changes Found for \`${component}\` in \`${stack}\``;
-        const body = `We have to limit summary because of GitHub limitation. Please check the logs for more details.`
+        const body = `We have to hide the summary because of GitHub limitation. Please check the logs for more details.`
         return [title, body].join("\n");
     }
 }

--- a/src/operations/create.js
+++ b/src/operations/create.js
@@ -54,9 +54,11 @@ class Create {
     shortSummary() {
         const component = this.state.metadata.component;
         const stack = this.state.metadata.stack;
-        return this.state.error ?
+        const title = this.state.error ?
           `## Plan Failed for \`${component}\` in \`${stack}\`` :
           `## Changes Found for \`${component}\` in \`${stack}\``;
+        const body = `We have to limit summary because of GitHub limitation. Please check the logs for more details.`
+        return [title, body].join("\n");
     }
 }
 

--- a/src/operations/create.js
+++ b/src/operations/create.js
@@ -1,7 +1,7 @@
 const core = require("@actions/core");
 const {NewCreated} = require("../results/new-created");
 const {readFileSync} = require("fs");
-const {getFileName} = require("../action");
+const {getFileName} = require("../utils");
 
 class Create {
     constructor(state, users, labels) {

--- a/src/operations/create.js
+++ b/src/operations/create.js
@@ -51,6 +51,13 @@ class Create {
         return readFileSync(file, 'utf-8');
     }
 
+    shortSummary() {
+        const component = this.state.metadata.component;
+        const stack = this.state.metadata.stack;
+        return this.state.error ?
+          `## Plan Failed for \`${component}\` in \`${stack}\`` :
+          `## Changes Found for \`${component}\` in \`${stack}\``;
+    }
 }
 
 

--- a/src/operations/create.js
+++ b/src/operations/create.js
@@ -57,7 +57,7 @@ class Create {
         const title = this.state.error ?
           `## Plan Failed for \`${component}\` in \`${stack}\`` :
           `## Changes Found for \`${component}\` in \`${stack}\``;
-        const body = `We have to hide the summary because of GitHub limitation. Please check the logs for more details.`
+        const body = `Summary is unavailable due to [GitHub size limitation](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#step-isolation-and-limits) on job summaries. Please check the GitHub Action run logs for more details.`
         return [title, body].join("\n");
     }
 }

--- a/src/operations/nothing.js
+++ b/src/operations/nothing.js
@@ -11,6 +11,10 @@ class Nothing {
     summary() {
         return "";
     }
+
+    shortSummary() {
+        return "";
+    }
 }
 
 

--- a/src/operations/remove.js
+++ b/src/operations/remove.js
@@ -34,7 +34,7 @@ class Remove {
 
         core.info(`Issue ${issueNumber} for component ${slug} has been closed with comment: ${comment}`);
 
-        return new Removed(github.context.runId, repository, issueNumber, this.state);
+        return new Removed(github.context.runId, repository, issueNumber, this.issue);
     }
 
     summary() {

--- a/src/operations/remove.js
+++ b/src/operations/remove.js
@@ -40,6 +40,9 @@ class Remove {
     summary() {
         return "";
     }
+    shortSummary() {
+        return "";
+    }
 }
 
 

--- a/src/operations/remove.js
+++ b/src/operations/remove.js
@@ -34,7 +34,7 @@ class Remove {
 
         core.info(`Issue ${issueNumber} for component ${slug} has been closed with comment: ${comment}`);
 
-        return new Removed(github.context.runId, repository, this.issue, this.state);
+        return new Removed(github.context.runId, repository, issueNumber, this.state);
     }
 
     summary() {

--- a/src/operations/skip.js
+++ b/src/operations/skip.js
@@ -1,6 +1,5 @@
-const {None} = require("../results/none");
-const {NewCreated} = require("../results/new-created");
 const {NewSkipped} = require("../results/new-skipped");
+const {readFileSync} = require("fs");
 
 class Skip {
     constructor(issue, state, maxNumberOpenedIssues) {
@@ -15,7 +14,9 @@ class Skip {
     }
 
     summary() {
-        return "";
+        const file_name = this.state.slug.replace("/", "_")
+        const file = `step-summary-${file_name}.md`;
+        return readFileSync(file, 'utf-8');
     }
 }
 

--- a/src/operations/skip.js
+++ b/src/operations/skip.js
@@ -1,5 +1,6 @@
 const {NewSkipped} = require("../results/new-skipped");
 const {readFileSync} = require("fs");
+const {getFileName} = require("../action");
 
 class Skip {
     constructor(issue, state, maxNumberOpenedIssues) {
@@ -14,7 +15,7 @@ class Skip {
     }
 
     summary() {
-        const file_name = this.state.slug.replace("/", "_")
+        const file_name = getFileName(this.state.slug);
         const file = `step-summary-${file_name}.md`;
         return readFileSync(file, 'utf-8');
     }

--- a/src/operations/skip.js
+++ b/src/operations/skip.js
@@ -22,9 +22,11 @@ class Skip {
     shortSummary() {
         const component = this.state.metadata.component;
         const stack = this.state.metadata.stack;
-        return this.state.error ?
+        const title = this.state.error ?
           `## Plan Failed for \`${component}\` in \`${stack}\`` :
           `## Changes Found for \`${component}\` in \`${stack}\``;
+        const body = `We have to hide the summary because of GitHub limitation. Please check the logs for more details.`
+        return [title, body].join("\n");
     }
 }
 

--- a/src/operations/skip.js
+++ b/src/operations/skip.js
@@ -1,6 +1,6 @@
 const {NewSkipped} = require("../results/new-skipped");
 const {readFileSync} = require("fs");
-const {getFileName} = require("../action");
+const {getFileName} = require("../utils");
 
 class Skip {
     constructor(issue, state, maxNumberOpenedIssues) {

--- a/src/operations/skip.js
+++ b/src/operations/skip.js
@@ -26,7 +26,7 @@ class Skip {
         const title = this.state.error ?
           `## Plan Failed for \`${component}\` in \`${stack}\`` :
           `## Changes Found for \`${component}\` in \`${stack}\``;
-        const body = `We have to hide the summary because of GitHub limitation. Please check the logs for more details.`
+        const body = `Summary is unavailable due to [GitHub size limitation](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#step-isolation-and-limits) on job summaries. Please check the GitHub Action run logs for more details.`
         return [title, body].join("\n");
     }
 }

--- a/src/operations/skip.js
+++ b/src/operations/skip.js
@@ -1,13 +1,17 @@
 const {None} = require("../results/none");
+const {NewCreated} = require("../results/new-created");
+const {NewSkipped} = require("../results/new-skipped");
 
 class Skip {
-    constructor(issue, state) {
+    constructor(issue, state, maxNumberOpenedIssues) {
         this.issue = issue;
         this.state = state;
+        this.maxNumberOpenedIssues = maxNumberOpenedIssues;
     }
 
-    async run() {
-        return new None();
+    async run(octokit, context) {
+        const repository = context.repo;
+        return new NewSkipped(context.runId, repository, this.maxNumberOpenedIssues, this.state);
     }
 
     summary() {

--- a/src/operations/skip.js
+++ b/src/operations/skip.js
@@ -18,6 +18,14 @@ class Skip {
         const file = `step-summary-${file_name}.md`;
         return readFileSync(file, 'utf-8');
     }
+
+    shortSummary() {
+        const component = this.state.metadata.component;
+        const stack = this.state.metadata.stack;
+        return this.state.error ?
+          `## Plan Failed for \`${component}\` in \`${stack}\`` :
+          `## Changes Found for \`${component}\` in \`${stack}\``;
+    }
 }
 
 

--- a/src/operations/update.js
+++ b/src/operations/update.js
@@ -3,9 +3,10 @@ const {readFileSync} = require("fs");
 const {Exists} = require("../results/exists");
 
 class Update {
-    constructor(issue, state) {
+    constructor(issue, state, labels) {
         this.issue = issue;
         this.state = state;
+        this.labels = labels;
     }
 
     async run(octokit, context) {
@@ -15,11 +16,13 @@ class Update {
         const file_name = slug.replace("/", "_")
         const issueDescription = readFileSync(`issue-description-${file_name}.md`, 'utf8');
         const issueNumber = this.issue.number;
+        const label = this.state.error ? "error" : "drift"
 
         octokit.rest.issues.update({
             ...repository,
             issue_number: issueNumber,
-            body: issueDescription
+            body: issueDescription,
+            labels: [label].concat(this.labels)
         });
 
         core.info(`Updated issue: ${issueNumber}`);

--- a/src/operations/update.js
+++ b/src/operations/update.js
@@ -1,7 +1,7 @@
 const core = require("@actions/core");
 const {readFileSync} = require("fs");
 const {Exists} = require("../results/exists");
-const {getFileName} = require("../action");
+const {getFileName} = require("../utils");
 
 class Update {
     constructor(issue, state, labels) {

--- a/src/operations/update.js
+++ b/src/operations/update.js
@@ -14,6 +14,7 @@ class Update {
 
         const slug = this.state.slug;
         const file_name = slug.replace("/", "_")
+        const issueTitle = this.state.error ? `Failure Detected in \`${slug}\`` : `Drift Detected in \`${slug}\``;
         const issueDescription = readFileSync(`issue-description-${file_name}.md`, 'utf8');
         const issueNumber = this.issue.number;
         const label = this.state.error ? "error" : "drift"
@@ -21,6 +22,7 @@ class Update {
         octokit.rest.issues.update({
             ...repository,
             issue_number: issueNumber,
+            title: issueTitle,
             body: issueDescription,
             labels: [label].concat(this.labels)
         });

--- a/src/operations/update.js
+++ b/src/operations/update.js
@@ -45,7 +45,7 @@ class Update {
         const title = this.state.error ?
           `## Plan Failed for \`${component}\` in \`${stack}\`` :
           `## Changes Found for \`${component}\` in \`${stack}\``;
-        const body = `We have to hide the summary because of GitHub limitation. Please check the logs for more details.`
+        const body = `Summary is unavailable due to [GitHub size limitation](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#step-isolation-and-limits) on job summaries. Please check the GitHub Action run logs for more details.`
         return [title, body].join("\n");
     }
 }

--- a/src/operations/update.js
+++ b/src/operations/update.js
@@ -41,9 +41,11 @@ class Update {
     shortSummary() {
         const component = this.state.metadata.component;
         const stack = this.state.metadata.stack;
-        return this.state.error ?
+        const title = this.state.error ?
           `## Plan Failed for \`${component}\` in \`${stack}\`` :
           `## Changes Found for \`${component}\` in \`${stack}\``;
+        const body = `We have to hide the summary because of GitHub limitation. Please check the logs for more details.`
+        return [title, body].join("\n");
     }
 }
 

--- a/src/operations/update.js
+++ b/src/operations/update.js
@@ -1,6 +1,7 @@
 const core = require("@actions/core");
 const {readFileSync} = require("fs");
 const {Exists} = require("../results/exists");
+const {getFileName} = require("../action");
 
 class Update {
     constructor(issue, state, labels) {
@@ -13,7 +14,7 @@ class Update {
         const repository = context.repo;
 
         const slug = this.state.slug;
-        const file_name = slug.replace("/", "_")
+        const file_name = getFileName(slug)
         const issueTitle = this.state.error ? `Failure Detected in \`${slug}\`` : `Drift Detected in \`${slug}\``;
         const issueDescription = readFileSync(`issue-description-${file_name}.md`, 'utf8');
         const issueNumber = this.issue.number;
@@ -33,7 +34,7 @@ class Update {
     }
 
     summary() {
-        const file_name = this.state.slug.replace("/", "_")
+        const file_name = getFileName(this.state.slug);
         const file = `step-summary-${file_name}.md`;
         return readFileSync(file, 'utf-8');
     }

--- a/src/operations/update.js
+++ b/src/operations/update.js
@@ -37,6 +37,14 @@ class Update {
         const file = `step-summary-${file_name}.md`;
         return readFileSync(file, 'utf-8');
     }
+
+    shortSummary() {
+        const component = this.state.metadata.component;
+        const stack = this.state.metadata.stack;
+        return this.state.error ?
+          `## Plan Failed for \`${component}\` in \`${stack}\`` :
+          `## Changes Found for \`${component}\` in \`${stack}\``;
+    }
 }
 
 

--- a/src/results/exists.js
+++ b/src/results/exists.js
@@ -12,14 +12,14 @@ class Exists {
         const repo = this.repository.repo;
         const runId = this.runId;
         const issueNumber = this.newIssueNumber;
-        const component = `[${slug}](https://github.com/${orgName}/${repo}/actions/runs/${runId}#user-content-result-${slug})`;
+        const component = `[${slug}](/${orgName}/${repo}/actions/runs/${runId}#user-content-result-${slug})`;
         const state = this.state.error ?
             '![failed](https://shields.io/badge/FAILED-ff0000?style=for-the-badge "Failed")' :
             '![drifted](https://shields.io/badge/DRIFTED-important?style=for-the-badge "Drifted")';
 
         const comments = this.state.error ?
-            `Failure detected. Issue already exists [#${issueNumber}](https://github.com/${orgName}/${repo}/issues/${issueNumber})` :
-            `Drift detected. Issue already exists [#${issueNumber}](https://github.com/${orgName}/${repo}/issues/${issueNumber})`;
+            `Failure detected. Issue already exists [#${issueNumber}](/${orgName}/${repo}/issues/${issueNumber})` :
+            `Drift detected. Issue already exists [#${issueNumber}](/${orgName}/${repo}/issues/${issueNumber})`;
 
         return [component, state, comments].join(" | ");
     }

--- a/src/results/new-created.js
+++ b/src/results/new-created.js
@@ -19,7 +19,7 @@ class NewCreated {
 
         const comments = this.state.error ?
             `Failure detected. Created new issue [#${issueNumber}](https://github.com/${orgName}/${repo}/issues/${issueNumber})` :
-            `New drift detected. Created new issue [#${issueNumber}](https://github.com/${orgName}/${repo}/issues/${issueNumber})`;
+            `Drift detected. Created new issue [#${issueNumber}](https://github.com/${orgName}/${repo}/issues/${issueNumber})`;
 
         return [component, state, comments].join(" | ");
     }

--- a/src/results/new-created.js
+++ b/src/results/new-created.js
@@ -12,14 +12,14 @@ class NewCreated {
         const repo = this.repository.repo;
         const runId = this.runId;
         const issueNumber = this.newIssueNumber;
-        const component = `[${slug}](https://github.com/${orgName}/${repo}/actions/runs/${runId}#user-content-result-${slug})`;
+        const component = `[${slug}](/${orgName}/${repo}/actions/runs/${runId}#user-content-result-${slug})`;
         const state = this.state.error ?
             `![failed](https://shields.io/badge/FAILED-ff0000?style=for-the-badge "Failed")` :
             '![drifted](https://shields.io/badge/DRIFTED-important?style=for-the-badge "Drifted")';
 
         const comments = this.state.error ?
-            `Failure detected. Created new issue [#${issueNumber}](https://github.com/${orgName}/${repo}/issues/${issueNumber})` :
-            `Drift detected. Created new issue [#${issueNumber}](https://github.com/${orgName}/${repo}/issues/${issueNumber})`;
+            `Failure detected. Created new issue [#${issueNumber}](/${orgName}/${repo}/issues/${issueNumber})` :
+            `Drift detected. Created new issue [#${issueNumber}](/${orgName}/${repo}/issues/${issueNumber})`;
 
         return [component, state, comments].join(" | ");
     }

--- a/src/results/new-skipped.js
+++ b/src/results/new-skipped.js
@@ -19,7 +19,7 @@ class NewSkipped {
 
         const comments = this.state.error ?
             `Failure detected. Issue was not created because maximum number of created issues ${maxOpenedIssues} reached` :
-            `New drift detected. Issue was not created because maximum number of created issues ${maxOpenedIssues} reached`;
+            `Drift detected. Issue was not created because maximum number of created issues ${maxOpenedIssues} reached`;
 
         return [component, state, comments].join(" | ");
     }

--- a/src/results/new-skipped.js
+++ b/src/results/new-skipped.js
@@ -12,7 +12,7 @@ class NewSkipped {
         const repo = this.repository.repo;
         const runId = this.runId;
         const maxOpenedIssues = this.maxNumberOpenedIssues;
-        const component = `[${slug}](https://github.com/${orgName}/${repo}/actions/runs/${runId}#user-content-result-${slug})`;
+        const component = `[${slug}](/${orgName}/${repo}/actions/runs/${runId}#user-content-result-${slug})`;
         const state = this.state.error ?
             `![failed](https://shields.io/badge/FAILED-ff0000?style=for-the-badge "Failed")` :
             '![drifted](https://shields.io/badge/DRIFTED-important?style=for-the-badge "Drifted")';

--- a/src/results/recovered.js
+++ b/src/results/recovered.js
@@ -12,12 +12,12 @@ class Recovered {
         const repo = this.repository.repo;
         const runId = this.runId;
         const issueNumber = this.newIssueNumber;
-        const component = `[${slug}](https://github.com/${orgName}/${repo}/actions/runs/${runId}#user-content-result-${slug})`;
+        const component = `[${slug}](/${orgName}/${repo}/actions/runs/${runId}#user-content-result-${slug})`;
         const state = `![recovered](https://shields.io/badge/RECOVERED-brightgreen?style=for-the-badge "Recovered")`;
 
         const comments = this.state.error ?
-            `Failure recovered. Closed issue [#${issueNumber}](https://github.com/${orgName}/${repo}/issues/${issueNumber})` :
-            `Drift recovered. Closed issue [#${issueNumber}](https://github.com/${orgName}/${repo}/issues/${issueNumber})`;
+            `Failure recovered. Closed issue [#${issueNumber}](/${orgName}/${repo}/issues/${issueNumber})` :
+            `Drift recovered. Closed issue [#${issueNumber}](/${orgName}/${repo}/issues/${issueNumber})`;
 
         return [component, state, comments].join(" | ");
     }

--- a/src/results/removed.js
+++ b/src/results/removed.js
@@ -12,9 +12,9 @@ class Removed {
         const repo = this.repository.repo;
         const runId = this.runId;
         const issueNumber = this.newIssueNumber;
-        const component = `[${slug}](https://github.com/${orgName}/${repo}/actions/runs/${runId}#user-content-result-${slug})`;
+        const component = `[${slug}](/${orgName}/${repo}/actions/runs/${runId}#user-content-result-${slug})`;
         const state = `![removed](https://shields.io/badge/REMOVED-grey?style=for-the-badge "Removed")`;
-        const comments = `Component has been removed. Closed issue [#${issueNumber}](https://github.com/${orgName}/${repo}/issues/${issueNumber})`;
+        const comments = `Component has been removed. Closed issue [#${issueNumber}](/${orgName}/${repo}/issues/${issueNumber})`;
 
         return [component, state, comments].join(" | ");
     }

--- a/src/results/removed.js
+++ b/src/results/removed.js
@@ -1,13 +1,13 @@
 class Removed {
-    constructor(runId, repository, newIssueNumber, state) {
+    constructor(runId, repository, newIssueNumber, issue) {
         this.runId = runId;
         this.repository = repository;
         this.newIssueNumber = newIssueNumber;
-        this.state = state;
+        this.issue = issue;
     }
 
     render() {
-        const slug = this.state.slug;
+        const slug = this.issue.slug;
         const orgName = this.repository.owner;
         const repo = this.repository.repo;
         const runId = this.runId;

--- a/src/utils.js
+++ b/src/utils.js
@@ -16,7 +16,13 @@ const parseIntInput = (valueString, defaultValue = 0) => {
     return value;
 };
 
+const getFileName = (slug) => {
+    return slug.replace(/\//g, "_");
+};
+
+
 module.exports = {
     parseCsvInput,
-    parseIntInput
+    parseIntInput,
+    getFileName
 };


### PR DESCRIPTION
## what
* Refactoring of the action
* Added tests
* Added `process-all` flag 
* Fix the action failure in case all affected stacks have not changed (artifact does not exist)
* Fix the bug when an issue has wrong metadata or no metadata at all
* Fix the bug when the summary size runs out of 1Mb limit

## why
* Improve code readability
* Gain insurance in the action stability
* Fix the bug when the action runs in the `apply` workflow to close issues created by the `drift detection` workflow.
* Fix apply and drift detection workflow when there is no stack with drift or error
* Avoid failing of `apply` and `drift detection` workflows because of wrong metadata in one issue
* Avoid errors because a summary is too big

## references
* https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#step-isolation-and-limits
* https://cloudposse.atlassian.net/browse/DEV-1562
* https://cloudposse.atlassian.net/browse/DEV-1561
* https://cloudposse.atlassian.net/browse/DEV-1560
* https://cloudposse.atlassian.net/browse/DEV-1555
* https://cloudposse.atlassian.net/browse/DEV-1559
* https://cloudposse.atlassian.net/browse/DEV-1135
