### PR TITLE
fix: summary file crashes

### DIFF
--- a/src/action.js
+++ b/src/action.js
@@ -259,6 +259,11 @@ const createIssues = async (octokit, context, maxOpenedIssues, labels, users, co
         const slug = componentsCandidatesToCreateIssue[i];
         const issueTitle = erroredComponents.includes(slug) ? `Failure Detected in \`${slug}\`` : `Drift Detected in \`${slug}\``;
         const file_name = slug.replace("/", "_")
+        // Before we read the issue description, test that the file exists
+        if (!fs.existsSync(`issue-description-${file_name}.md`)) {
+            core.error(`Failed to create issue for component ${slug} because issue description file issue-description-${file_name}.md does not exist`);
+            continue;
+        }
         const issueDescription = fs.readFileSync(`issue-description-${file_name}.md`, 'utf8');
 
         const label  = erroredComponents.includes(slug) ? "error" : "drift"

--- a/src/action.js
+++ b/src/action.js
@@ -258,10 +258,9 @@ const createIssues = async (octokit, context, maxOpenedIssues, labels, users, co
     for (let i = 0; i < numOfIssuesToCreate; i++) {
         const slug = componentsCandidatesToCreateIssue[i];
         const issueTitle = erroredComponents.includes(slug) ? `Failure Detected in \`${slug}\`` : `Drift Detected in \`${slug}\``;
-        const file_name = slug.replace("/", "_")
-        // Before we read the issue description, test that the file exists
+        const file_name = slug.replace(/\//g, "_")
         if (!fs.existsSync(`issue-description-${file_name}.md`)) {
-            core.error(`Failed to create issue for component ${slug} because issue description file issue-description-${file_name}.md does not exist`);
+            core.error(`Failed to create issue for component ${slug} because file "issue-description-${file_name}.md" does not exist`);
             continue;
         }
         const issueDescription = fs.readFileSync(`issue-description-${file_name}.md`, 'utf8');
@@ -304,7 +303,7 @@ const updateIssues = async (octokit, context, componentsToIssues, componentsToUp
 
     for (let i = 0; i < componentsToUpdateExistingIssue.length; i++) {
       const slug = componentsToUpdateExistingIssue[i];
-      const file_name = slug.replace("/", "_")
+      const file_name = slug.replace(/\//g, "_")
       const issueDescription = fs.readFileSync(`issue-description-${file_name}.md`, 'utf8');
       const issueNumber = componentsToIssues[slug].number;
 
@@ -395,7 +394,7 @@ const postStepSummaries = async (driftingComponents, erroredComponents) => {
     const components = driftingComponents.concat(erroredComponents)
     for (let i = 0; i < components.length; i++) {
       const slug = components[i];
-      const file_name = slug.replace("/", "_")
+      const file_name = slug.replace(/\//g, "_")
       const file = `step-summary-${file_name}.md`;
       const content = fs.readFileSync(file, 'utf-8');
 


### PR DESCRIPTION
## what

- fix(action): look for descriptions before loading them
- fix(action/file_name): replace all instances of slash


## why
- If a component has multiple slashes in its name, it won't be found
- if a file isn't found, the reconcile workflow exits immediately instead of
skipping

