### PR TITLE
fix: `comment-no-changes.md` file name

### DIFF
--- a/src/action.js
+++ b/src/action.js
@@ -280,7 +280,7 @@ const runAction = async (octokit, context, parameters) => {
   const assets_path = path.resolve(__dirname + '/../assets')
 
   if (context.payload.pull_request != null) {
-    const fileName = operations.length > 0 ? `${assets_path}/comment.md` : `${assets_path}/comments-no-changes.md`
+    const fileName = operations.length > 0 ? `${assets_path}/comment.md` : `${assets_path}/comment-no-changes.md`
     const title = [readFileSync(fileName, 'utf-8')]
     await postComment(octokit, context, title)
   }


### PR DESCRIPTION
## what
- corrected file name for `comment-no-changes.md`

## why
- It had a typo in the name. It was `comments-no-changes.md`

## references
- customer engagement

