### PR TITLE
chore: upgrade action runtime to Node 24

### DIFF
--- a/.github/workflows/pr-comment-test.yml
+++ b/.github/workflows/pr-comment-test.yml
@@ -11,6 +11,7 @@ permissions:
   id-token: write
   contents: read
   issues: write
+  pull-requests: write
 
 jobs:
   setup:
@@ -45,7 +46,7 @@ jobs:
         with:
           max-opened-issues: '4'
           labels: "test-pr-comments"
-          token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
     outputs:
       result: ${{ steps.current.outcome }}

--- a/.github/workflows/pr-comment-test.yml
+++ b/.github/workflows/pr-comment-test.yml
@@ -20,12 +20,12 @@ jobs:
       - name: Setup
         run: echo "Do setup"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: metadata-${{ github.run_id }}-test-pr-comments
           path: ./tests/fixtures/metadata
@@ -36,7 +36,7 @@ jobs:
     continue-on-error: true
     needs: [setup]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'success'
           actual: "${{ needs.test.outputs.result }}"
@@ -81,7 +81,7 @@ jobs:
           echo "Count of found issues: $issue_count"
           echo "count=$issue_count" >> $GITHUB_OUTPUT
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: '4'
           actual: "${{ steps.test.outputs.count }}"

--- a/.github/workflows/pr-comment-test.yml
+++ b/.github/workflows/pr-comment-test.yml
@@ -62,12 +62,17 @@ jobs:
 
       - name: Find all issues
         id: issues
-        uses: actions-cool/issues-helper@v3
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          actions: 'find-issues'
-          token: ${{ github.token }}
-          labels: 'test-pr-comments'
-          issue-state: 'open'
+          script: |
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'test-pr-comments',
+              state: 'open',
+              per_page: 100,
+            });
+            core.setOutput('issues', JSON.stringify(issues.filter(i => !i.pull_request)));
 
       - name: Count found issues
         id: test
@@ -90,8 +95,21 @@ jobs:
         run: echo "Do Tear down"
 
       - name: Close all matching issues
-        uses: actions-cool/issues-helper@v3
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          actions: 'close-issues'
-          token: ${{ github.token }}
-          labels: 'test-pr-comments'
+          script: |
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'test-pr-comments',
+              state: 'open',
+              per_page: 100,
+            });
+            for (const issue of issues.filter(i => !i.pull_request)) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+              });
+            }

--- a/.github/workflows/test-changes-exists-drift.yml
+++ b/.github/workflows/test-changes-exists-drift.yml
@@ -69,12 +69,17 @@ jobs:
 
       - name: Find all issues
         id: issues
-        uses: actions-cool/issues-helper@v3
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          actions: 'find-issues'
-          token: ${{ github.token }}
-          labels: 'test-changes-exists'
-          issue-state: 'open'
+          script: |
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'test-changes-exists',
+              state: 'open',
+              per_page: 100,
+            });
+            core.setOutput('issues', JSON.stringify(issues.filter(i => !i.pull_request)));
 
       - name: Count found issues
         id: test
@@ -97,8 +102,21 @@ jobs:
         run: echo "Do Tear down"
 
       - name: Close all matching issues
-        uses: actions-cool/issues-helper@v3
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          actions: 'close-issues'
-          token: ${{ github.token }}
-          labels: 'test-changes-exists'
+          script: |
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'test-changes-exists',
+              state: 'open',
+              per_page: 100,
+            });
+            for (const issue of issues.filter(i => !i.pull_request)) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+              });
+            }

--- a/.github/workflows/test-changes-exists-drift.yml
+++ b/.github/workflows/test-changes-exists-drift.yml
@@ -27,12 +27,12 @@ jobs:
       - name: Setup
         run: echo "Do setup"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: metadata-${{ github.run_id }}-test-changes-exist-drift
           path: ./tests/fixtures/metadata
@@ -43,7 +43,7 @@ jobs:
     continue-on-error: true
     needs: [setup]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'success'
           actual: "${{ needs.test.outputs.result }}"
@@ -88,7 +88,7 @@ jobs:
           echo "Count of found issues: $issue_count"
           echo "count=$issue_count" >> $GITHUB_OUTPUT
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: '4'
           actual: "${{ steps.test.outputs.count }}"

--- a/.github/workflows/test-changes-exists-drift.yml
+++ b/.github/workflows/test-changes-exists-drift.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           max-opened-issues: '4'
           labels: "test-changes-exists"
-          token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
     outputs:
       result: ${{ steps.current.outcome }}

--- a/.github/workflows/test-max-opened-issues.yml
+++ b/.github/workflows/test-max-opened-issues.yml
@@ -28,12 +28,12 @@ jobs:
       - name: Setup
         run: echo "Do setup"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: metadata-${{ github.run_id }}-test-max-opened-issues
           path: ./tests/fixtures/metadata
@@ -44,7 +44,7 @@ jobs:
     continue-on-error: true
     needs: [setup]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'success'
           actual: "${{ needs.test.outputs.result }}"
@@ -89,7 +89,7 @@ jobs:
           echo "Count of found issues: $issue_count"
           echo "count=$issue_count" >> $GITHUB_OUTPUT
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: '3'
           actual: "${{ steps.test.outputs.count }}"

--- a/.github/workflows/test-max-opened-issues.yml
+++ b/.github/workflows/test-max-opened-issues.yml
@@ -70,12 +70,17 @@ jobs:
 
       - name: Find all issues
         id: issues
-        uses: actions-cool/issues-helper@v3
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          actions: 'find-issues'
-          token: ${{ github.token }}
-          labels: 'test-max-opened-issues'
-          issue-state: 'open'
+          script: |
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'test-max-opened-issues',
+              state: 'open',
+              per_page: 100,
+            });
+            core.setOutput('issues', JSON.stringify(issues.filter(i => !i.pull_request)));
 
       - name: Count found issues
         id: test
@@ -98,8 +103,21 @@ jobs:
         run: echo "Do Tear down"
 
       - name: Close all matching issues
-        uses: actions-cool/issues-helper@v3
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          actions: 'close-issues'
-          token: ${{ github.token }}
-          labels: 'test-max-opened-issues'
+          script: |
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'test-max-opened-issues',
+              state: 'open',
+              per_page: 100,
+            });
+            for (const issue of issues.filter(i => !i.pull_request)) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+              });
+            }

--- a/.github/workflows/test-max-opened-issues.yml
+++ b/.github/workflows/test-max-opened-issues.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           max-opened-issues: '3'
           labels: "test-max-opened-issues"
-          token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
     outputs:
       result: ${{ steps.current.outcome }}

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -5,26 +5,8 @@ on:
   pull_request:
 
 jobs:
-  validate-codeowners:
-    runs-on: ubuntu-latest
-    steps:
-    - name: "Checkout source code at current commit"
-      uses: actions/checkout@v4
-      # Leave pinned at 0.7.1 until https://github.com/mszostok/codeowners-validator/issues/173 is resolved
-    - uses: mszostok/codeowners-validator@v0.7.1
-      if: github.event.pull_request.head.repo.full_name == github.repository
-      name: "Full check of CODEOWNERS"
-      with:
-        # For now, remove "files" check to allow CODEOWNERS to specify non-existent
-        # files so we can use the same CODEOWNERS file for Terraform and non-Terraform repos
-        #   checks: "files,syntax,owners,duppatterns"
-        checks: "syntax,owners,duppatterns"
-        owner_checker_allow_unowned_patterns: "false"
-        # GitHub access token is required only if the `owners` check is enabled
-        github_access_token: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
-    - uses: mszostok/codeowners-validator@v0.7.1
-      if: github.event.pull_request.head.repo.full_name != github.repository
-      name: "Syntax check of CODEOWNERS"
-      with:
-        checks: "syntax,duppatterns"
-        owner_checker_allow_unowned_patterns: "false"
+  ci-codeowners:
+    uses: cloudposse/.github/.github/workflows/shared-codeowners.yml@main
+    with:
+      is_fork: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+    secrets: inherit

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -4,6 +4,9 @@ on:
 
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   ci-codeowners:
     uses: cloudposse/.github/.github/workflows/shared-codeowners.yml@main

--- a/action.yml
+++ b/action.yml
@@ -33,5 +33,5 @@ inputs:
     default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
 
 runs:
-    using: 'node20'
+    using: 'node24'
     main: 'dist/index.js'


### PR DESCRIPTION
## what

* Change the action runtime from `node20` to `node24` in `action.yml`
* Repair this repo's long-red CI so the runtime change is actually verified:
  * `validate-codeowners.yml` now calls the org-standard `shared-codeowners.yml@main` reusable
    workflow (same pattern as `test-helpers`), with least-privilege `permissions: contents: read` —
    the previous inline validator used `secrets.PUBLIC_REPO_ACCESS_TOKEN`, which no longer exists
  * `test-changes-exists-drift.yml`, `test-max-opened-issues.yml`, and `pr-comment-test.yml` now use
    the default `GITHUB_TOKEN` instead of the removed `PUBLIC_REPO_ACCESS_TOKEN` (`issues: write`
    was already declared; added `pull-requests: write` for the PR-comment test)
  * The find/close-issues-by-label test steps now use first-party `actions/github-script`
    (SHA-pinned `# v9.0.0`) instead of `actions-cool/issues-helper`, whose repository is blocked by
    the org's Actions allow-list ("Repository access blocked" at job setup)

## why

* GitHub is deprecating the Node 20 runtime; actions declaring `runs.using: node20` emit a
  deprecation warning for every consumer and are already being force-migrated to Node 24
* Every test workflow in this repo had been failing on all branches since at least July for the
  reasons above; with these fixes the test suite runs the committed bundle end-to-end via
  `uses: ./` on Node 24 and passes

## references

* https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
